### PR TITLE
Add flake8 plugin pep8-naming as development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Current Main
 
 - Add check and custom exception for an invalid indicator layer combination during initialization of indicator objects ([#28])
-- Add pep8-naming package as development dependency ([#40])
+- Add pre-commit check for [PEP 8] conform names by adding the pep8-naming package as development dependency ([#40])
 
 [#28]: https://github.com/GIScience/ohsome-quality-analyst/pull/28
+[#40]: https://github.com/GIScience/ohsome-quality-analyst/pull/40
+[PEP 8]: https://www.python.org/dev/peps/pep-0008/
 
 
 ## 0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Main
 
 - Add check and custom exception for an invalid indicator layer combination during initialization of indicator objects ([#28])
+- Add pep8-naming package as development dependency ([#40])
 
 [#28]: https://github.com/GIScience/ohsome-quality-analyst/pull/28
 

--- a/workers/ohsome_quality_analyst/api.py
+++ b/workers/ohsome_quality_analyst/api.py
@@ -18,14 +18,13 @@ logging.debug("Debugging output enabled")
 
 
 def empty_api_response() -> dict:
-    RESPONSE_TEMPLATE = {
+    return {
         "attribution": {
             "url": "https://ohsome.org/copyrights",
             "text": "© OpenStreetMap contributors",
         },
         "apiVersion": oqt_version,
     }
-    return RESPONSE_TEMPLATE
 
 
 async def load_bpolys(bpolys: str) -> None:

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
@@ -32,13 +32,13 @@ class GhsPopComparisonBuildings(BaseIndicator):
         self.feature_count = None
         self.feature_count_per_sqkm = None
 
-    def greenThresholdFunction(self, pop_per_sqkm) -> float:
+    def green_threshold_function(self, pop_per_sqkm) -> float:
         # TODO: Add docstring
         # TODO: adjust threshold functions
         # more precise values? maybe as fraction of the threshold functions?
         return 5.0 * np.sqrt(pop_per_sqkm)
 
-    def yellowThresholdFunction(self, pop_per_sqkm) -> float:
+    def yellow_threshold_function(self, pop_per_sqkm) -> float:
         # TODO: Add docstring
         # TODO: adjust threshold functions
         # more precise values? maybe as fraction of the threshold functions?
@@ -73,23 +73,23 @@ class GhsPopComparisonBuildings(BaseIndicator):
         if self.pop_count_per_sqkm == 0:
             return False
 
-        elif self.feature_count_per_sqkm <= self.yellowThresholdFunction(
+        elif self.feature_count_per_sqkm <= self.yellow_threshold_function(
             self.pop_count_per_sqkm
         ):
             self.result.value = (
                 self.feature_count_per_sqkm
-                / self.yellowThresholdFunction(self.pop_count_per_sqkm)
+                / self.yellow_threshold_function(self.pop_count_per_sqkm)
             ) * (0.5)
             self.result.description = (
                 description + self.metadata.label_description["red"]
             )
             self.result.label = "red"
 
-        elif self.feature_count_per_sqkm <= self.greenThresholdFunction(
+        elif self.feature_count_per_sqkm <= self.green_threshold_function(
             self.pop_count_per_sqkm
         ):
-            green = self.greenThresholdFunction(self.pop_count_per_sqkm)
-            yellow = self.yellowThresholdFunction(self.pop_count_per_sqkm)
+            green = self.green_threshold_function(self.pop_count_per_sqkm)
+            yellow = self.yellow_threshold_function(self.pop_count_per_sqkm)
             fraction = (self.feature_count_per_sqkm - yellow) / (green - yellow) * 0.5
             self.result.value = 0.5 + fraction
             self.result.description = (
@@ -127,8 +127,8 @@ class GhsPopComparisonBuildings(BaseIndicator):
         x = np.linspace(0, max_area, 20)
 
         # Plot thresholds as line.
-        y1 = [self.greenThresholdFunction(xi) for xi in x]
-        y2 = [self.yellowThresholdFunction(xi) for xi in x]
+        y1 = [self.green_threshold_function(xi) for xi in x]
+        y2 = [self.yellow_threshold_function(xi) for xi in x]
         line = line = ax.plot(
             x,
             y1,

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
@@ -32,14 +32,14 @@ class GhsPopComparisonRoads(BaseIndicator):
         self.feature_length = None
         self.feature_length_per_sqkm = None
 
-    def greenThresholdFunction(self, pop_per_sqkm) -> float:
+    def green_threshold_function(self, pop_per_sqkm) -> float:
         """Return road density threshold for green label."""
         if pop_per_sqkm < 5000:
             return pop_per_sqkm / 500
         else:
             return 10
 
-    def yellowThresholdFunction(self, pop_per_sqkm) -> float:
+    def yellow_threshold_function(self, pop_per_sqkm) -> float:
         """Return road density threshold for yellow label."""
         if pop_per_sqkm < 5000:
             return pop_per_sqkm / 1000
@@ -73,8 +73,8 @@ class GhsPopComparisonRoads(BaseIndicator):
             feature_length_per_sqkm=round(self.feature_length_per_sqkm, 1),
         )
 
-        green_road_density = self.greenThresholdFunction(self.pop_count_per_sqkm)
-        yellow_road_density = self.yellowThresholdFunction(self.pop_count_per_sqkm)
+        green_road_density = self.green_threshold_function(self.pop_count_per_sqkm)
+        yellow_road_density = self.yellow_threshold_function(self.pop_count_per_sqkm)
 
         if self.pop_count_per_sqkm == 0:
             return False
@@ -124,8 +124,8 @@ class GhsPopComparisonRoads(BaseIndicator):
             max_area = round(self.pop_count_per_sqkm * 2 / 10) * 10
         x = np.linspace(0, max_area, 100)
         # Plot thresholds as line.
-        y1 = [self.greenThresholdFunction(xi) for xi in x]
-        y2 = [self.yellowThresholdFunction(xi) for xi in x]
+        y1 = [self.green_threshold_function(xi) for xi in x]
+        y2 = [self.yellow_threshold_function(xi) for xi in x]
         line = ax.plot(
             x,
             y1,

--- a/workers/ohsome_quality_analyst/indicators/last_edit/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/last_edit/indicator.py
@@ -131,7 +131,7 @@ class LastEdit(BaseIndicator):
             wedgeprops={"width": size, "alpha": 0.5},
         )
 
-        for c, s, l in zip(colors, sizes, labels):
+        for c, l in zip(colors, labels):
             handles.append(mpatches.Patch(color=c, label=f"{l}"))
 
         # Plot inner Pie (Indicator Value)

--- a/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
+++ b/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
@@ -1031,7 +1031,7 @@ class sigmoidCurve:
                 # get possible xmids
                 xmidvalues = self.sortInits5curves(df1.li, df1.yValues)[0]
                 # check for the xmids the mse error
-                for i, xval in enumerate(xmidvalues):
+                for xval in xmidvalues:
                     yPredX = self.logistic1(
                         xval, initParamsSingle[3], initParamsSingle[1], df1.li
                     )
@@ -1068,7 +1068,7 @@ class sigmoidCurve:
                 # incoms = [incom for incom in xmidvalues if str(incom) != 'nan']
                 # xmidvalues = incoms
                 # check for the xmids the mse error
-                for i, xval in enumerate(xmidvalues):
+                for xval in xmidvalues:
                     yPredX = self.logistic1(
                         xval, initParamsSingleB[3], initParamsSingleB[1], df1.li
                     )

--- a/workers/ohsome_quality_analyst/indicators/poi_density/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/poi_density/indicator.py
@@ -31,10 +31,10 @@ class PoiDensity(BaseIndicator):
         self.count = None
         self.density = None
 
-    def greenThresholdFunction(self, area):
+    def green_threshold_function(self, area):
         return self.threshold_yellow * area
 
-    def yellowThresholdFunction(self, area):
+    def yellow_threshold_function(self, area):
         return self.threshold_red * area
 
     async def preprocess(self) -> bool:
@@ -95,8 +95,8 @@ class PoiDensity(BaseIndicator):
         x = np.linspace(0, max_area, 2)
 
         # Plot thresholds as line.
-        y1 = [self.greenThresholdFunction(xi) for xi in x]
-        y2 = [self.yellowThresholdFunction(xi) for xi in x]
+        y1 = [self.green_threshold_function(xi) for xi in x]
+        y2 = [self.yellow_threshold_function(xi) for xi in x]
 
         line = ax.plot(
             x,

--- a/workers/ohsome_quality_analyst/indicators/tags_ratio/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/tags_ratio/indicator.py
@@ -115,7 +115,7 @@ class TagsRatio(BaseIndicator):
             wedgeprops={"width": size, "alpha": 0.5},
         )
 
-        for c, s, l in zip(colors, sizes, labels):
+        for c, l in zip(colors, labels):
             handles.append(mpatches.Patch(color=c, label=f"{l}"))
 
         # Plot inner Pie (Indicator Value)

--- a/workers/poetry.lock
+++ b/workers/poetry.lock
@@ -65,7 +65,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "certifi"
-version = "2020.12.5"
+version = "2021.5.30"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -73,7 +73,7 @@ python-versions = "*"
 
 [[package]]
 name = "cfgv"
-version = "3.2.0"
+version = "3.3.0"
 description = "Validate configuration and produce human readable error messages."
 category = "dev"
 optional = false
@@ -149,7 +149,7 @@ dev = ["pytest (>=5)", "pytest-cov", "coveralls", "black", "mypy", "pylint"]
 
 [[package]]
 name = "distlib"
-version = "0.3.1"
+version = "0.3.2"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -193,6 +193,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
+
+[[package]]
+name = "flake8-polyfill"
+version = "1.0.2"
+description = "Polyfill package for Flake8 plugins"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8 = "*"
 
 [[package]]
 name = "geojson"
@@ -245,7 +256,7 @@ http2 = ["h2 (>=3.0.0,<4.0.0)"]
 
 [[package]]
 name = "identify"
-version = "2.2.4"
+version = "2.2.7"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -399,6 +410,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pep8-naming"
+version = "0.11.1"
+description = "Check PEP-8 naming conventions, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8-polyfill = ">=1.0.2,<2"
+
+[[package]]
 name = "pillow"
 version = "8.2.0"
 description = "Python Imaging Library (Fork)"
@@ -419,7 +441,7 @@ dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "pre-commit"
-version = "2.12.1"
+version = "2.13.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
@@ -647,16 +669,16 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.4"
+version = "1.26.5"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
-brotli = ["brotlipy (>=0.6.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -689,7 +711,7 @@ yarl = {version = "*", markers = "python_version >= \"3.6\""}
 
 [[package]]
 name = "virtualenv"
-version = "20.4.6"
+version = "20.4.7"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -728,7 +750,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "2fbda54e91f4ca6e5fcf2b3f730a829e733b7208180049d4d1c82e1a4bb79300"
+content-hash = "6c666dc6d95bc25caf1a5e5241b43a166cf2b5cdb7c919a52c8de21ab6495bee"
 
 [metadata.files]
 appdirs = [
@@ -764,12 +786,12 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 certifi = [
-    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
-    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
 cfgv = [
-    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
-    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
+    {file = "cfgv-3.3.0-py2.py3-none-any.whl", hash = "sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1"},
+    {file = "cfgv-3.3.0.tar.gz", hash = "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1"},
 ]
 chardet = [
     {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
@@ -850,8 +872,8 @@ dacite = [
     {file = "dacite-1.6.0.tar.gz", hash = "sha256:d48125ed0a0352d3de9f493bf980038088f45f3f9d7498f090b50a847daaa6df"},
 ]
 distlib = [
-    {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
-    {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
+    {file = "distlib-0.3.2-py2.py3-none-any.whl", hash = "sha256:23e223426b28491b1ced97dc3bbe183027419dfc7982b4fa2f05d5f3ff10711c"},
+    {file = "distlib-0.3.2.zip", hash = "sha256:106fef6dc37dd8c0e2c0a60d3fca3e77460a48907f335fa28420463a6f799736"},
 ]
 fastapi = [
     {file = "fastapi-0.61.2-py3-none-any.whl", hash = "sha256:8c8517680a221e69eb34073adf46c503092db2f24845b7bdc7f85b54f24ff0df"},
@@ -864,6 +886,10 @@ filelock = [
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
+]
+flake8-polyfill = [
+    {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
+    {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
 ]
 geojson = [
     {file = "geojson-2.5.0-py2.py3-none-any.whl", hash = "sha256:ccbd13368dd728f4e4f13ffe6aaf725b6e802c692ba0dde628be475040c534ba"},
@@ -882,8 +908,8 @@ httpx = [
     {file = "httpx-0.17.1.tar.gz", hash = "sha256:cc2a55188e4b25272d2bcd46379d300f632045de4377682aa98a8a6069d55967"},
 ]
 identify = [
-    {file = "identify-2.2.4-py2.py3-none-any.whl", hash = "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"},
-    {file = "identify-2.2.4.tar.gz", hash = "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e"},
+    {file = "identify-2.2.7-py2.py3-none-any.whl", hash = "sha256:92d6ad08eca19ceb17576733759944b94c0761277ddc3acf65e75e57ef190e32"},
+    {file = "identify-2.2.7.tar.gz", hash = "sha256:c29e74c3671fe9537715cb695148231d777170ca1498e1c30c675d4ea782afe9"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1071,6 +1097,10 @@ pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
+pep8-naming = [
+    {file = "pep8-naming-0.11.1.tar.gz", hash = "sha256:a1dd47dd243adfe8a83616e27cf03164960b507530f155db94e10b36a6cd6724"},
+    {file = "pep8_naming-0.11.1-py2.py3-none-any.whl", hash = "sha256:f43bfe3eea7e0d73e8b5d07d6407ab47f2476ccaeff6937c84275cd30b016738"},
+]
 pillow = [
     {file = "Pillow-8.2.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9"},
     {file = "Pillow-8.2.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b"},
@@ -1104,6 +1134,7 @@ pillow = [
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
     {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pluggy = [
@@ -1111,8 +1142,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 pre-commit = [
-    {file = "pre_commit-2.12.1-py2.py3-none-any.whl", hash = "sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712"},
-    {file = "pre_commit-2.12.1.tar.gz", hash = "sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9"},
+    {file = "pre_commit-2.13.0-py2.py3-none-any.whl", hash = "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"},
+    {file = "pre_commit-2.13.0.tar.gz", hash = "sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -1177,18 +1208,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -1302,8 +1341,8 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
-    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+    {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
+    {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
 ]
 uvicorn = [
     {file = "uvicorn-0.12.3-py3-none-any.whl", hash = "sha256:562ef6aaa8fa723ab6b82cf9e67a774088179d0ec57cb17e447b15d58b603bcf"},
@@ -1314,8 +1353,8 @@ vcrpy = [
     {file = "vcrpy-4.1.1.tar.gz", hash = "sha256:57095bf22fc0a2d99ee9674cdafebed0f3ba763018582450706f7d3a74fff599"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.4.6-py2.py3-none-any.whl", hash = "sha256:307a555cf21e1550885c82120eccaf5acedf42978fd362d32ba8410f9593f543"},
-    {file = "virtualenv-20.4.6.tar.gz", hash = "sha256:72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4"},
+    {file = "virtualenv-20.4.7-py2.py3-none-any.whl", hash = "sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76"},
+    {file = "virtualenv-20.4.7.tar.gz", hash = "sha256:14fdf849f80dbb29a4eb6caa9875d476ee2a5cf76a5f5415fa2f1606010ab467"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/workers/pyproject.toml
+++ b/workers/pyproject.toml
@@ -39,6 +39,7 @@ schema = "^0.7.3"
 pytest = "^6.2.2"
 isort = "5.7.0"
 pytest-cov = "^2.12.0"
+pep8-naming = "^0.11.1"
 
 [tool.poetry.scripts]
 oqt = "ohsome_quality_analyst.cli:cli"

--- a/workers/setup.cfg
+++ b/workers/setup.cfg
@@ -11,6 +11,16 @@ ignore = W503, E203
 inline-quotes = double
 max-line-length = 88
 
+per-file-ignores =
+    # TODO: Fix issues causing those warnings
+    ohsome_quality_analyst/indicators/mapping_saturation/indicator.py:N806,N802
+    # TODO: Fix issues causing those warnings
+    ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py:N806,N802,N803,N801
+    # N803: function name should be lowercase (function names)
+    #   Ignore for Fast-API parameters which are definied as mixedCase
+    # N815: mixedCase variable in class scope (constants, method names)
+    #   Ignore for Fast-API parameters which are definied as mixedCase
+    ohsome_quality_analyst/api.py:N803,N815
 
 [isort]
 # https://github.com/timothycrosley/isort/wiki/isort-Settings

--- a/workers/tests/integrationtests/test_cli.py
+++ b/workers/tests/integrationtests/test_cli.py
@@ -24,7 +24,7 @@ class TestCliIntegration(unittest.TestCase):
         )
 
     @oqt_vcr.use_cassette()
-    def testCreateIndicator(self):
+    def test_create_indicator(self):
         result = self.runner.invoke(
             cli,
             [
@@ -42,14 +42,14 @@ class TestCliIntegration(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
 
     @oqt_vcr.use_cassette()
-    def testCreateReport(self):
+    def test_create_report(self):
         result = self.runner.invoke(
             cli,
             ["create-report", "-r", "SimpleReport", "-d", "regions", "-f", "3"],
         )
         self.assertEqual(result.exit_code, 0)
 
-    def testGetAvailableRegions(self):
+    def test_get_available_regions(self):
         result = self.runner.invoke(
             cli,
             ["-q", "list-regions"],

--- a/workers/tests/integrationtests/test_indicator_mapping_saturation.py
+++ b/workers/tests/integrationtests/test_indicator_mapping_saturation.py
@@ -36,7 +36,7 @@ class TestIndicatorMappingSaturation(unittest.TestCase):
         self.assertIsNotNone(indicator.result.svg)
 
     @oqt_vcr.use_cassette()
-    def testFloatDivisionByZeroError(self):
+    def test_float_division_by_zero_error(self):
         layer_name = "building_count"
         dataset = "regions"
         feature_id = 31
@@ -48,7 +48,7 @@ class TestIndicatorMappingSaturation(unittest.TestCase):
         indicator.create_figure()
 
     @oqt_vcr.use_cassette()
-    def testCannotConvertNanError(self):
+    def test_cannot_convert_nan_error(self):
         layer_name = "building_count"
         dataset = "regions"
         feature_id = 28

--- a/workers/tests/integrationtests/test_oqt.py
+++ b/workers/tests/integrationtests/test_oqt.py
@@ -14,7 +14,7 @@ class TestOqt(unittest.TestCase):
         self.bpolys = asyncio.run(db_client.get_bpolys_from_db(dataset, feature_id))
 
     @oqt_vcr.use_cassette()
-    def testCreateIndicatorFromScratch(self):
+    def test_create_indicator_from_scratch(self):
         # From scratch
         indicator = asyncio.run(
             oqt.create_indicator(
@@ -27,7 +27,7 @@ class TestOqt(unittest.TestCase):
         self.assertIsNotNone(indicator.result.svg)
 
     @oqt_vcr.use_cassette()
-    def testCreateIndicatorFromDatabase(self):
+    def test_create_indicator_from_database(self):
         # Invalid dataset name
         with self.assertRaises(ValueError):
             asyncio.run(
@@ -54,14 +54,14 @@ class TestOqt(unittest.TestCase):
         self.assertIsNotNone(indicator.result.svg)
 
     @oqt_vcr.use_cassette()
-    def testCreateReportFromScratch(self):
+    def test_create_report_from_scratch(self):
         report = asyncio.run(oqt.create_report("SimpleReport", self.bpolys))
         self.assertIsNotNone(report.result.label)
         self.assertIsNotNone(report.result.value)
         self.assertIsNotNone(report.result.description)
 
     @oqt_vcr.use_cassette()
-    def testCreateReportFromDatabase(self):
+    def test_create_report_from_database(self):
         report = asyncio.run(
             oqt.create_report("SimpleReport", dataset="regions", feature_id=3)
         )

--- a/workers/tests/unittests/test_api.py
+++ b/workers/tests/unittests/test_api.py
@@ -6,7 +6,7 @@ from ohsome_quality_analyst.api import load_bpolys
 
 
 class TestApiUnit(unittest.TestCase):
-    def testValidateBpolysSize(self):
+    def test_validate_bpolys_size(self):
         infile = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             "fixtures",

--- a/workers/tests/unittests/test_cli.py
+++ b/workers/tests/unittests/test_cli.py
@@ -20,30 +20,30 @@ class TestCliUnit(unittest.TestCase):
             "heidelberg_altstadt.geojson",
         )
 
-    def testCli(self):
+    def test_cli(self):
         result = self.runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
 
         result = self.runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
 
-    def testListIndicators(self):
+    def test_list_indicators(self):
         result = self.runner.invoke(cli, ["list-indicators"])
         assert result.exit_code == 0
 
-    def testListReports(self):
+    def test_list_reports(self):
         result = self.runner.invoke(cli, ["list-reports"])
         assert result.exit_code == 0
 
-    def testListLayers(self):
+    def test_list_layers(self):
         result = self.runner.invoke(cli, ["list-layers"])
         assert result.exit_code == 0
 
-    def testListDatasets(self):
+    def test_list_datasets(self):
         result = self.runner.invoke(cli, ["list-datasets"])
         assert result.exit_code == 0
 
-    def testCreateAllIndicators(self):
+    def test_create_all_indicators(self):
         result = self.runner.invoke(
             cli,
             ["create-all-indicators", "-d", "regions"],


### PR DESCRIPTION
### Description

* Add flake8-naming package as dev dependency.
* Add configuration to ignore flake8-naming warnings for Python files in `indicators/mapping-saturation/`

### New or changed dependencies
- pep8-naming

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- ~~[ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing~~ 
- ~~[ ] I have commented my code~~ 
- ~~[ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~~ 
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)