### PR TITLE
🚧 Fixing Bug in Report RemoteMappingLevelOne creation

### DIFF
--- a/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
+++ b/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
@@ -40,17 +40,21 @@ class RemoteMappingLevelOne(BaseReport):
             # TODO: Is it possible that a label == UNDEFINED?
             if indicator.result.label != "undefined":
                 values.append(indicator.result.value)
-        self.result.value = mean(values)
+        if len(values) != 0:
+            self.result.value = mean(values)
 
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
+            if self.result.value < 0.5:
+                self.result.label = "red"
+                self.result.description = self.metadata.label_description["red"]
+            elif self.result.value < 1:
+                self.result.label = "yellow"
+                self.result.description = self.metadata.label_description["yellow"]
+            elif self.result.value >= 1:
+                self.result.label = "green"
+                self.result.description = self.metadata.label_description["green"]
+            else:
+                self.result.label = None
+                self.result.description = "Could not derive quality level"
         else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+            self.result.label = "undefined"
+            self.result.description = self.metadata.label_description["undefined"]

--- a/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
+++ b/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
@@ -56,5 +56,6 @@ class RemoteMappingLevelOne(BaseReport):
                 self.result.label = None
                 self.result.description = "Could not derive quality level"
         else:
+            self.result.value = -1
             self.result.label = "undefined"
             self.result.description = self.metadata.label_description["undefined"]


### PR DESCRIPTION
### Description
The creation of the Report RemoteMappingLevelOne fails in regions where no mapping has taken place.
Report RemoteMappingLevelOne should be set to the label undefined if all indicators are undefined


### Corresponding issue
Closes #32 


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
