### PR TITLE
Implement combine_indicators() as Concrete Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add option to select different datasets and fid fields as input to OQT ([#4])
 - Rewrite save and load indicator from database logic to use one result table for all indicator results ([#37])
 - Remove GUF Comparison indicator ([#55])
+- Implement combine_indicators() as Concrete Method of the Base Blass Report ([53])
 
 [#28]: https://github.com/GIScience/ohsome-quality-analyst/pull/28
 [#40]: https://github.com/GIScience/ohsome-quality-analyst/pull/40
@@ -16,6 +17,7 @@
 [#4]: https://github.com/GIScience/ohsome-quality-analyst/issues/4
 [#37]: https://github.com/GIScience/ohsome-quality-analyst/pull/37
 [#55]: https://github.com/GIScience/ohsome-quality-analyst/pull/55
+[#53]: https://github.com/GIScience/ohsome-quality-analyst/pull/53
 
 
 ## 0.3.1

--- a/workers/ohsome_quality_analyst/base/report.py
+++ b/workers/ohsome_quality_analyst/base/report.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Literal, NamedTuple, Tuple
 
 from dacite import from_dict
 from geojson import FeatureCollection
+
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.utils.definitions import get_metadata
 

--- a/workers/ohsome_quality_analyst/reports/jrc_requirements/report.py
+++ b/workers/ohsome_quality_analyst/reports/jrc_requirements/report.py
@@ -1,6 +1,3 @@
-import logging
-from statistics import mean
-
 from geojson import FeatureCollection
 
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
@@ -52,23 +49,4 @@ class JrcRequirements(BaseReport):
         )
 
     def combine_indicators(self) -> None:
-        logging.info(f"Combine indicators for report: {self.metadata.name}")
-
-        values = []
-        for indicator in self.indicators:
-            if indicator.result.label != "undefined":
-                values.append(indicator.result.value)
-        self.result.value = mean(values)
-
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
-        else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+        super().combine_indicators()

--- a/workers/ohsome_quality_analyst/reports/map_action_poc/report.py
+++ b/workers/ohsome_quality_analyst/reports/map_action_poc/report.py
@@ -1,6 +1,3 @@
-import logging
-from statistics import mean
-
 from geojson import FeatureCollection
 
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
@@ -34,23 +31,4 @@ class MapActionPoc(BaseReport):
         )
 
     def combine_indicators(self) -> None:
-        logging.info(f"Combine indicators for report: {self.metadata.name}")
-
-        values = []
-        for indicator in self.indicators:
-            if indicator.result.label != "undefined":
-                values.append(indicator.result.value)
-        self.result.value = mean(values)
-
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
-        else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+        super().combine_indicators()

--- a/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
+++ b/workers/ohsome_quality_analyst/reports/remote_mapping_level_one/report.py
@@ -1,6 +1,3 @@
-import logging
-from statistics import mean
-
 from geojson import FeatureCollection
 
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
@@ -33,24 +30,4 @@ class RemoteMappingLevelOne(BaseReport):
         )
 
     def combine_indicators(self) -> None:
-        logging.info(f"Combine indicators for report: {self.metadata.name}")
-
-        values = []
-        for indicator in self.indicators:
-            # TODO: Is it possible that a label == UNDEFINED?
-            if indicator.result.label != "undefined":
-                values.append(indicator.result.value)
-        self.result.value = mean(values)
-
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
-        else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+        super().combine_indicators()

--- a/workers/ohsome_quality_analyst/reports/simple_report/report.py
+++ b/workers/ohsome_quality_analyst/reports/simple_report/report.py
@@ -1,6 +1,3 @@
-import logging
-from statistics import mean
-
 from geojson import FeatureCollection
 
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
@@ -25,24 +22,4 @@ class SimpleReport(BaseReport):
         )
 
     def combine_indicators(self) -> None:
-        """Combine the results of all indicators."""
-        logging.info(f"Combine indicators for report: {self.metadata.name}")
-
-        # get mean of indicator quality values
-        values = []
-        for indicator in self.indicators:
-            if indicator.result.label != "undefined":
-                values.append(indicator.result.value)
-        self.result.value = mean(values)
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
-        else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+        super().combine_indicators()

--- a/workers/ohsome_quality_analyst/reports/sketchmap_fitness/report.py
+++ b/workers/ohsome_quality_analyst/reports/sketchmap_fitness/report.py
@@ -1,6 +1,3 @@
-import logging
-from statistics import mean
-
 from geojson import FeatureCollection
 
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
@@ -27,25 +24,4 @@ class SketchmapFitness(BaseReport):
         )
 
     def combine_indicators(self) -> None:
-        logging.info(f"Combine indicators for report: {self.metadata.name}")
-
-        # get mean of indicator quality values
-        values = []
-        for indicator in self.indicators:
-            # TODO: Is it possible that a label == UNDEFINED?
-            if indicator.result.label != "undefined":
-                values.append(indicator.result.value)
-        self.result.value = mean(values)
-
-        if self.result.value < 0.5:
-            self.result.label = "red"
-            self.result.description = self.metadata.label_description["red"]
-        elif self.result.value < 1:
-            self.result.label = "yellow"
-            self.result.description = self.metadata.label_description["yellow"]
-        elif self.result.value >= 1:
-            self.result.label = "green"
-            self.result.description = self.metadata.label_description["green"]
-        else:
-            self.result.label = None
-            self.result.description = "Could not derive quality level"
+        super().combine_indicators()


### PR DESCRIPTION
### Description

Implement combine_indicators() as Concrete Method of the Base Blass `Report`.
This provides a default method for combining indicators to all reports.
This will also reduce code duplication across those report (child classes).

Closes #32 

### Todo

- [x] Include fix of issue #32 by implementing solution of PR #52 


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
