### PR TITLE
Fix CLI help bug

### DIFF
--- a/workers/ohsome_quality_analyst/cli_opts.py
+++ b/workers/ohsome_quality_analyst/cli_opts.py
@@ -18,6 +18,8 @@ class IntOrStrParamType(click.ParamType):
     https://click.palletsprojects.com/en/8.0.x/parameters/#implementing-custom-types
     """
 
+    name = "integer|string"
+
     def convert(self, value, param, ctx):
         try:
             return int(value)

--- a/workers/tests/unittests/test_cli.py
+++ b/workers/tests/unittests/test_cli.py
@@ -43,6 +43,10 @@ class TestCliUnit(unittest.TestCase):
         result = self.runner.invoke(cli, ["list-datasets"])
         assert result.exit_code == 0
 
+    def test_create_indicator_help(self):
+        result = self.runner.invoke(cli, ["create-indicator", "--help"])
+        assert result.exit_code == 0
+
     def test_create_all_indicators(self):
         result = self.runner.invoke(
             cli,


### PR DESCRIPTION
### Description

This bug has been caused due to missing name attribute of custom click
type class (feature_id_field)

### Corresponding issue
Closes #58

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
