### PR TITLE
Added workaround for failing DB-build using Windows to troubleshooting doc

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,9 @@ Install pyqt5: https://www.riverbankcomputing.com/static/Docs/PyQt5/installation
 ## Windows
 
 It's best to use WSL2 (https://docs.microsoft.com/en-us/windows/wsl/install-win10). Make sure to have WSL2 installed, not WSL.
-Docker on Windows WSL:
+
+Building the database using the Windows command line usually fails, as the files are written for Linux. A simple workaround is to install the app `Ubuntu 20.04 LTS` from the Windows store and run the command for building the database within this app. 
+If the building of the database still fails, this usually happens as windows changes file endings. Open the file `\ohsome-quality-analyst\database\init_db.development\schema.dev.sh` in an editor and change the format of line endings to UNIX (LF) (Using Notepad: `Edit` --> `EOL Conversion` --> `Unix (LF)`).
 
 
 ### Pre commit: ImportError: DLL load failed while importing \_sqlite3: The specified module could not be found.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ Install pyqt5: https://www.riverbankcomputing.com/static/Docs/PyQt5/installation
 It's best to use WSL2 (https://docs.microsoft.com/en-us/windows/wsl/install-win10). Make sure to have WSL2 installed, not WSL.
 
 Building the database using the Windows command line usually fails, as the files are written for Linux. A simple workaround is to install the app `Ubuntu 20.04 LTS` from the Windows store and run the command for building the database within this app. 
-If the building of the database still fails, this usually happens as windows changes file endings. Open the file `\ohsome-quality-analyst\database\init_db.development\schema.dev.sh` in an editor and change the format of line endings to UNIX (LF) (Using Notepad: `Edit` --> `EOL Conversion` --> `Unix (LF)`).
+If the building of the database still fails, this usually happens as windows changes file endings. Open the file `\ohsome-quality-analyst\database\init_db.development\schema.dev.sh` in an editor and change the format of line endings to UNIX (LF) (Using Notepad++: `Edit` --> `EOL Conversion` --> `Unix (LF)`).
 
 
 ### Pre commit: ImportError: DLL load failed while importing \_sqlite3: The specified module could not be found.


### PR DESCRIPTION
### Description
Added a workaround to the troubleshooting document for failing DB builts on Windows. Suggests to use the Ubuntu command line for Windows and Notepad++


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- ~~My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing~~
- ~~I have commented my code~~
- ~~I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~~
- ~~I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~~

