### PR TITLE
Set log level of PyTest to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Other Changes
 
 - Set proper User Agent for requests to the ohsome API ([#62])
+- Set log level matplotlib fontmanager to INFO ([#90])
 
 [#62]: https://github.com/GIScience/ohsome-quality-analyst/issues/62
+[#90]: https://github.com/GIScience/ohsome-quality-analyst/issues/90
 
 
 ## 0.4.0

--- a/workers/ohsome_quality_analyst/utils/definitions.py
+++ b/workers/ohsome_quality_analyst/utils/definitions.py
@@ -105,6 +105,8 @@ def load_logging_config():
 
 def configure_logging() -> None:
     """Configure logging level and format"""
+    # Avoid a huge amount of DEBUG logs from matplotlib font_manager.py
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.INFO)
     logging.config.dictConfig(load_logging_config())
 
 


### PR DESCRIPTION
### Description

When a test fails PyTest will print out logs of log level Debug. This leads to a cluttered terminal screen since alot of debug messages from third party libraries will be printed out to stdout.

This PR will set the log level to INFO to reduce messages to stdout.

### Checklist

- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.