### PR TITLE
make VCR mode configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 - Set proper User Agent for requests to the ohsome API ([#62])
 - Set log level matplotlib fontmanager to INFO ([#90])
+- Make VCR mode configurable ([#95])
 
 [#62]: https://github.com/GIScience/ohsome-quality-analyst/issues/62
 [#90]: https://github.com/GIScience/ohsome-quality-analyst/issues/90
+[#95]: https://github.com/GIScience/ohsome-quality-analyst/pull/95
 
 
 ## 0.4.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                   sh 'while ! pg_isready --host ${POSTGRES_HOST} --port ${POSTGRES_PORT}; do sleep 5; done'
                 }
                 // run pytest
-                sh 'cd ${WORK_DIR} && ${POETRY_RUN} pytest --cov=ohsome_quality_analyst --cov-report=xml tests'
+                sh 'cd ${WORK_DIR} && VCR_RECORD_MODE=none ${POETRY_RUN} pytest --cov=ohsome_quality_analyst --cov-report=xml tests'
                 // replace absolute dir in the coverage file with actually used dir for sonar-scanner
                 sh "sed -i \"s#${WORK_DIR}#${WORKSPACE}/${MODULE_DIR}#g\" ${WORK_DIR}/coverage.xml"
                 // run static analysis with sonar-scanner

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -182,7 +182,9 @@ pytest tests
 ##### VCR (videocassette recorder) for tests
 
 All tests that are calling function, which are dependent on external resources (e.g. ohsome API) have to use the [VCR.py](https://vcrpy.readthedocs.io) module: "VCR.py records all HTTP interactions that take place […]."
-This ensures that the positive test result is not dependent on the external resource. The cassettes are stored in the test directory within [fixtures/vcr_cassettes](/workers/tests/integrationtests/fixtures/vcr_cassettes). These cassettes are supposed to be integrated (committed and pushed) to the repository. If necessary, the cassettes can be re-recorded by deleting the cassettes and run all tests again. This is not necessary in normal cases, because not-yet-stored requests are downloaded automatically.
+This ensures that the positive test result is not dependent on the external resource. The cassettes are stored in the test directory within [fixtures/vcr_cassettes](/workers/tests/integrationtests/fixtures/vcr_cassettes). These cassettes are supposed to be integrated (committed and pushed) to the repository.
+
+The VCR [record mode](https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes) is configurable through the environment variable `VCR_RECORD_MODE`. To ensure that every request is covered by cassettes, run the tests with the record mode `none`. If necessary, the cassettes can be re-recorded by deleting the cassettes and run all tests again, or using the record mode `all`. This is not necessary in normal cases, because not-yet-stored requests are downloaded automatically.
 
 Writing tests using VCR.py with our custom decorator is as easy as: 
 

--- a/workers/tests/integrationtests/utils.py
+++ b/workers/tests/integrationtests/utils.py
@@ -17,7 +17,8 @@ def filename_generator(function):
 oqt_vcr = vcr.VCR(
     serializer="json",
     cassette_library_dir=FIXTURE_DIR,
-    record_mode="new_episodes",
+    # details see https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes
+    record_mode=os.getenv("VCR_RECORD_MODE", default="new_episodes"),
     match_on=["method", "scheme", "host", "port", "path", "query", "body"],
     func_path_generator=filename_generator,
 )


### PR DESCRIPTION
### Description
This change allows to configure if the tests never query the ohsome API but fail, or recreate all VCR cassettes, see https://vcrpy.readthedocs.io/en/latest/usage.html#record-modesv

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
