### PR TITLE
Jenkins: add project version and python version to sonar scanner analysis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,8 @@ pipeline {
                 withSonarQubeEnv('sonarcloud GIScience/ohsome') {
                   sh "${scannerHome}/bin/sonar-scanner " +
                     "-Dsonar.branch.name=${env.BRANCH_NAME} " +
-                    "-Dsonar.python.coverage.reportPaths=${WORK_DIR}/coverage.xml"
+                    "-Dsonar.python.coverage.reportPaths=${WORK_DIR}/coverage.xml" +
+                    "-Dsonar.projectVersion=${VERSION}"
                 }
                 // run other static code analysis
                 sh 'cd ${WORK_DIR} && ${POETRY_RUN} black --check --diff --no-color .'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,9 @@ sonar.organization=giscience
 sonar.projectKey=ohsome-quality-analyst
 sonar.projectName=ohsome quality analyst
 
+# supported Python versions
+sonar.python.version=3.8, 3.9
+
 # disable PL/SQL
 sonar.plsql.file.suffixes=""
 


### PR DESCRIPTION
* The analysis done by the sonar scanner is currently missing the project version. This PR adds the missing version. More information: https://sonarcloud.io/documentation/improving/new-code/
* The supported Python versions weren't specified for the sonar scanner. More information: https://sonarcloud.io/documentation/advanced-setup/languages/python/