### PR TITLE
Fixing saturation indicator bug

### DIFF
--- a/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
+++ b/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
@@ -1022,25 +1022,26 @@ class sigmoidCurve:
             "logistic4",
             "logistic5",
         ]
-
-        def check_no_nan_element(element):
-            return not math.isnan(element)
-
         # initial values for the single sigmoid curve
         initParamsSingle = self.initparamsingle(df1.li, df1.yValues)
         errorsListSingle = []
         if not math.isnan(initParamsSingle[3]):
             inits5curves = self.sortInits5curves(df1.li, df1.yValues)
+            # add up the 2 lists and then check each of the 4 values,
+            # if they are not nan
             validity_result = all(
-                map(
-                    check_no_nan_element,
-                    [
-                        math.fsum(inits5curves[0]),
-                        math.fsum(inits5curves[1]),
-                        inits5curves[2],
-                        inits5curves[3],
-                    ],
-                )
+                [
+                    not x
+                    for x in map(
+                        math.isnan,
+                        [
+                            math.fsum(inits5curves[0]),
+                            math.fsum(inits5curves[1]),
+                            inits5curves[2],
+                            inits5curves[3],
+                        ],
+                    )
+                ]
             )
             if validity_result is True:
                 # get possible xmids
@@ -1078,15 +1079,18 @@ class sigmoidCurve:
             errorsListSingle = []
             inits5curves = self.sortInits5curves(df1.li, df1.yValues)
             validity_result = all(
-                map(
-                    check_no_nan_element,
-                    [
-                        math.fsum(inits5curves[0]),
-                        math.fsum(inits5curves[1]),
-                        inits5curves[2],
-                        inits5curves[3],
-                    ],
-                )
+                [
+                    not x
+                    for x in map(
+                        math.isnan,
+                        [
+                            math.fsum(inits5curves[0]),
+                            math.fsum(inits5curves[1]),
+                            inits5curves[2],
+                            inits5curves[3],
+                        ],
+                    )
+                ]
             )
             if validity_result is True:
                 # get possible xmids

--- a/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
+++ b/workers/ohsome_quality_analyst/indicators/mapping_saturation/sigmoid_curve.py
@@ -1022,12 +1022,27 @@ class sigmoidCurve:
             "logistic4",
             "logistic5",
         ]
+
+        def check_no_nan_element(element):
+            return not math.isnan(element)
+
         # initial values for the single sigmoid curve
         initParamsSingle = self.initparamsingle(df1.li, df1.yValues)
         errorsListSingle = []
         if not math.isnan(initParamsSingle[3]):
             inits5curves = self.sortInits5curves(df1.li, df1.yValues)
-            if not math.isnan(inits5curves[3]):
+            validity_result = all(
+                map(
+                    check_no_nan_element,
+                    [
+                        math.fsum(inits5curves[0]),
+                        math.fsum(inits5curves[1]),
+                        inits5curves[2],
+                        inits5curves[3],
+                    ],
+                )
+            )
+            if validity_result is True:
                 # get possible xmids
                 xmidvalues = self.sortInits5curves(df1.li, df1.yValues)[0]
                 # check for the xmids the mse error
@@ -1062,7 +1077,18 @@ class sigmoidCurve:
         if not math.isnan(initParamsSingleB[3]):
             errorsListSingle = []
             inits5curves = self.sortInits5curves(df1.li, df1.yValues)
-            if not math.isnan(inits5curves[3]):
+            validity_result = all(
+                map(
+                    check_no_nan_element,
+                    [
+                        math.fsum(inits5curves[0]),
+                        math.fsum(inits5curves[1]),
+                        inits5curves[2],
+                        inits5curves[3],
+                    ],
+                )
+            )
+            if validity_result is True:
                 # get possible xmids
                 xmidvalues = self.sortInits5curves(df1.li, df1.yValues)[0]
                 # incoms = [incom for incom in xmidvalues if str(incom) != 'nan']


### PR DESCRIPTION

Prevent the mapping saturation indicator from returning nan-Values as result if data is available. See Issue #45 for bug description

### Corresponding issue
Closes #45 

### New or changed dependencies
-

### Checklist
- [ ] I have updated my branch to `main` (e.g. through `git rebase main`)
- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
