### PR TITLE
drop unused UI code, and dependency to jQuery completely

### DIFF
--- a/website/website/assets/js/map-en.js
+++ b/website/website/assets/js/map-en.js
@@ -475,21 +475,6 @@ function buildMap(...charts){
 	};
 
 
-
-	// Text showing in info box before and while selecting a layer
-	$('.leaflet-control-layers-selector').click(function(){
-
-		var inside = document.getElementsByClassName("info").item(0);
-		// set timeslider to first year (2010)
-
-
-		if(map.hasLayer(world)) {
-			inside.innerHTML = '<p>Move the mouse over the map</p>';
-		}			;
-
-
-	});
-
 	// method that we will use to update the info box based on feature properties passed
 	info.updateInfo = function (id) {
 		// depending on selected layer, show corresponding information

--- a/website/website/index.html
+++ b/website/website/index.html
@@ -33,10 +33,6 @@
 		integrity="sha512-GffPMF3RvMeYyc1LWMHtK8EbPv0iNZ8/oTtHPx9/cc2ILxQ+u905qIwdpULaqDkyBKgOaB57QTMg7ztg8Jm2Og=="
 		crossorigin=""></script>
 	
-		<!-- Add jQuery -->
-		<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-		<script defer src="https://code.jquery.com/jquery-3.3.1.js"></script>
-		
 		<!-- Add custom css and js-->
 		<link type="text/css" rel="stylesheet" href="assets/css/style.css">
 		<link type="text/css" rel="stylesheet" href="assets/css/custom-spinner.css">


### PR DESCRIPTION
### Description
Removes a unused section of code: As far as I can see the map never has a layer control, so the onclick handler can never be triggered.

And as a consequence, remove the jQuery library, which is AFAICS no where else used in the project. Btw, jQuery was included twice in two slightly different versions from two different CDNs. :see_no_evil: 
