### PR TITLE
 Save indicator as GeoJSON Feature to DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Main
 
+### Breaking Changes
+
+- Save indicator as GeoJSON Feature to DB ([#149])
+    - Extend database schema with one additional attribute `feature` of type JSON
+
 ### New Features
 
 - Add API-endpoints to list indicators, reports, layers, datasets and feature id fields ([#106])
@@ -10,8 +15,13 @@
 
 - Added documentation on “How to add a layer definitions” ([#141])
 
+### How to upgrade?
+
+- If you set up your own database you will need to rebuild the database or delete the results table (`DROP TABLE results;`).
+
 [#106]: https://github.com/GIScience/ohsome-quality-analyst/issues/106
 [#141]: https://github.com/GIScience/ohsome-quality-analyst/pull/141
+[#149]: https://github.com/GIScience/ohsome-quality-analyst/pull/149
 
 
 ## 0.5.1

--- a/database/scripts/queries/get_results_as_geojson.sql
+++ b/database/scripts/queries/get_results_as_geojson.sql
@@ -1,0 +1,4 @@
+SELECT
+    json_build_object('type', 'FeatureCollection', 'features', json_agg(feature))
+FROM
+    results;

--- a/workers/ohsome_quality_analyst/geodatabase/client.py
+++ b/workers/ohsome_quality_analyst/geodatabase/client.py
@@ -14,6 +14,7 @@ On preventing SQL injections:
     please make sure no SQL injection attack is possible.
 """
 
+import json
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -24,6 +25,7 @@ import geojson
 from geojson import Feature, FeatureCollection, MultiPolygon, Polygon
 
 from ohsome_quality_analyst.utils.definitions import DATASETS
+from ohsome_quality_analyst.utils.helper import datetime_to_isostring_timestamp
 
 
 @asynccontextmanager
@@ -72,7 +74,7 @@ async def save_indicator_results(indicator, dataset: str, feature_id: str) -> No
         indicator.result.value,
         indicator.result.description,
         indicator.result.svg,
-        indicator.as_feature(),
+        json.dumps(indicator.as_feature(), default=datetime_to_isostring_timestamp),
     )
 
     async with get_connection() as conn:

--- a/workers/ohsome_quality_analyst/geodatabase/client.py
+++ b/workers/ohsome_quality_analyst/geodatabase/client.py
@@ -72,6 +72,7 @@ async def save_indicator_results(indicator, dataset: str, feature_id: str) -> No
         indicator.result.value,
         indicator.result.description,
         indicator.result.svg,
+        indicator.as_feature(),
     )
 
     async with get_connection() as conn:

--- a/workers/ohsome_quality_analyst/geodatabase/create_results_table.sql
+++ b/workers/ohsome_quality_analyst/geodatabase/create_results_table.sql
@@ -9,5 +9,6 @@ CREATE TABLE IF NOT EXISTS results (
     result_value float,  -- VALUE is an SQL keyword
     result_description text,
     result_svg text,
+    feature json,
     PRIMARY KEY (indicator_name, layer_name, dataset_name, fid)
 );

--- a/workers/ohsome_quality_analyst/geodatabase/load_results.sql
+++ b/workers/ohsome_quality_analyst/geodatabase/load_results.sql
@@ -8,7 +8,8 @@ SELECT
     result_label,
     result_value,
     result_description,
-    result_svg
+    result_svg,
+    feature
 FROM
     results
 WHERE

--- a/workers/ohsome_quality_analyst/geodatabase/save_results.sql
+++ b/workers/ohsome_quality_analyst/geodatabase/save_results.sql
@@ -8,7 +8,8 @@ INSERT INTO results (
     result_label,
     result_value,
     result_description,
-    result_svg)
+    result_svg,
+    feature)
 VALUES (
     $1,
     $2,
@@ -19,7 +20,8 @@ VALUES (
     $7,
     $8,
     $9,
-    $10)
+    $10,
+    $11)
 ON CONFLICT (
     indicator_name,
     layer_name,
@@ -32,10 +34,12 @@ ON CONFLICT (
             result_label,
             result_value,
             result_description,
-            result_svg) = (
+            result_svg,
+            feature) = (
             excluded.timestamp_oqt,
             excluded.timestamp_osm,
             excluded.result_label,
             excluded.result_value,
             excluded.result_description,
-            excluded.result_svg);
+            excluded.result_svg,
+            excluded.feature);

--- a/workers/tests/integrationtests/test_geodatabase.py
+++ b/workers/tests/integrationtests/test_geodatabase.py
@@ -1,6 +1,8 @@
 import asyncio
 import unittest
 
+import geojson
+
 import ohsome_quality_analyst.geodatabase.client as db_client
 from ohsome_quality_analyst.indicators.ghs_pop_comparison_buildings.indicator import (
     GhsPopComparisonBuildings,
@@ -30,6 +32,11 @@ class TestGeodatabase(unittest.TestCase):
         # TODO: split tests by functionality (load and safe),
         # but load test needs a saved indicator.
         # save
+
+        async def _fetchval(query):
+            async with db_client.get_connection() as conn:
+                return await conn.fetchval(query)
+
         self.indicator = GhsPopComparisonBuildings(
             layer_name="building_count",
             feature=self.feature,
@@ -42,6 +49,16 @@ class TestGeodatabase(unittest.TestCase):
                 self.indicator, self.dataset, self.feature_id
             )
         )
+        query = (
+            "SELECT feature "
+            + "FROM results "
+            + "WHERE indicator_name = 'GHS-POP Comparison Buildings' "
+            + "AND layer_name = 'Building Count' "
+            + "AND dataset_name = 'regions' "
+            + "AND fid = '3';"
+        )
+        result = asyncio.run(_fetchval(query))
+        self.assertTrue(geojson.loads(result).is_valid)
 
         # load
         self.indicator = GhsPopComparisonBuildings(


### PR DESCRIPTION
### Description
Extend database schema with one additional attribute of type JSON.
During saving indicator attribute to database, dump the
indicator.as_feature() output to the database as well. The reason is to
not lose any data when saving and loading and indicator from and to the
database such as the indicator.data attribute (see issue #145).

Workflow to save and load an indicator form the database will stay the same.
This work will be helpful in solving issue #145.

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)