### PR TITLE
Fix API invalid geojson response of `/regions`

### DIFF
--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -231,7 +231,8 @@ async def _fetch_report(
 async def get_available_regions():
     """List names of available regions."""
     response = empty_api_response()
-    response["result"] = await db_client.get_available_regions()
+    regions = await db_client.get_available_regions()
+    response.update(regions)
     return response
 
 

--- a/workers/tests/integrationtests/test_api.py
+++ b/workers/tests/integrationtests/test_api.py
@@ -20,7 +20,7 @@ class TestApi(unittest.TestCase):
         url = "/regions"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        _geojson = json.dumps(json.loads(response.content)["result"])
+        _geojson = json.dumps(json.loads(response.content))
         self.assertTrue(geojson.loads(_geojson).is_valid)
 
     def test_get_list_indicators(self):


### PR DESCRIPTION
### Description
Since commit c736f10 the response of the API endpoint `/regions` has not been a valid GeoJSON anymore. This broke the display of regions on the website if there where not locally (in the website directory) available.

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- ~[ ] I have commented my code~
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~
