### PR TITLE
Load indicator from DB will load data attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add and improve tests for API ([#168])
     - Add test cases covering the content of GeoJSON properties.
     - Improve API response schemata by using less logic to create the schemata.
+- Load indicator from DB will also load its data attributes ([#179])
 
 ### How to upgrade?
 
@@ -30,6 +31,7 @@
 [#149]: https://github.com/GIScience/ohsome-quality-analyst/pull/149
 [#153]: https://github.com/GIScience/ohsome-quality-analyst/pull/153
 [#168]: https://github.com/GIScience/ohsome-quality-analyst/pull/168
+[#179]: https://github.com/GIScience/ohsome-quality-analyst/pull/179
 [`pydantic`]: https://pydantic-docs.helpmanual.io/
 
 

--- a/workers/ohsome_quality_analyst/utils/helper.py
+++ b/workers/ohsome_quality_analyst/utils/helper.py
@@ -125,6 +125,31 @@ def flatten_dict(input_dict: dict, *, separator: str = ".", prefix: str = "") ->
         return {prefix: input_dict}
 
 
+def unflatten_dict(input_dict: dict, *, separator: str = "."):
+    """Returns the given one-level dict as unflatten dict."""
+    output_dict = {}
+    for k, v in input_dict.items():
+        keys = k.split(separator)
+        temp_dict = {}
+        for i, key in enumerate(reversed(keys)):
+            if i == 0:
+                temp_dict = {key: v}
+            else:
+                temp_dict = {key: temp_dict}
+        output_dict = merge_dicts(output_dict, temp_dict)
+    return output_dict
+
+
+def merge_dicts(dict1, dict2):
+    """Merges two nested dictionaries."""
+    for key in dict2:
+        if key in dict1:
+            merge_dicts(dict1[key], dict2[key])
+        else:
+            dict1[key] = dict2[key]
+    return dict1
+
+
 def flatten_sequence(input_seq: Union[dict, list, tuple, set]) -> list:
     """Returns the given input sequence as a list.
 

--- a/workers/tests/integrationtests/test_geodatabase.py
+++ b/workers/tests/integrationtests/test_geodatabase.py
@@ -75,6 +75,12 @@ class TestGeodatabase(unittest.TestCase):
         self.assertIsNotNone(self.indicator.result.description)
         self.assertIsNotNone(self.indicator.result.svg)
 
+        # Test if data attributes were set
+        self.assertIsNotNone(self.indicator.pop_count)
+        self.assertIsNotNone(self.indicator.area)
+        self.assertIsNotNone(self.indicator.pop_count_per_sqkm)
+        self.assertIsNotNone(self.indicator.feature_count)
+
     def test_get_feature_ids(self):
         results = asyncio.run(db_client.get_feature_ids(self.dataset))
         self.assertIsInstance(results, list)

--- a/workers/tests/unittests/test_helper.py
+++ b/workers/tests/unittests/test_helper.py
@@ -12,7 +12,9 @@ from ohsome_quality_analyst.utils.helper import (
     flatten_dict,
     flatten_sequence,
     loads_geojson,
+    merge_dicts,
     name_to_class,
+    unflatten_dict,
 )
 
 
@@ -79,6 +81,17 @@ class TestHelper(unittest.TestCase):
         deep = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}
         flat = {"foo.bar": "baz", "foo.lang.нет": "tak", "something": 5}
         self.assertDictEqual(flatten_dict(deep), flat)
+
+    def test_unflatten_dict(self):
+        flat = {"foo.bar": "baz", "foo.lang.нет": "tak", "something": 5}
+        deep = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}
+        self.assertDictEqual(unflatten_dict(flat), deep)
+
+    def test_merge_dicts(self):
+        dict1 = {"foo": {"bar": "baz"}}
+        dict2 = {"foo": {"lang": {"нет": "tak"}}, "something": 5}
+        merged_dict = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}
+        self.assertDictEqual(merge_dicts(dict1, dict2), merged_dict)
 
     # TODO: add tests for other input than dict
     def test_flatten_seq(self):


### PR DESCRIPTION
### Description
Now loading an indicator from the DB will not only load the indicator results but also
any arbitrary data (the indicator attributes) which has been calculated
and saved to the DB as JSON.

### Corresponding issue
Closes #145

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
