### PR TITLE
Change output format of the API endpoint `/regions` to a JSON Array of key-value maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Save indicator as GeoJSON Feature to DB ([#149])
     - Extend database schema with one additional attribute `feature` of type JSON
+- API endpoint `/regions` responds with array of names and ids (default) or a GeoJSON if parameter `asGeoJSON=True` is set ([#171] [#195]).
 
 ### New Features
 
@@ -21,12 +22,13 @@
     - Improve API response schemata by using less logic to create the schemata.
 - Add list indicator/layer combinations for API and CLI([#99])
 - Load indicator from DB will also load its data attributes ([#179])
-- Add parameter to 'regions' endpoint to only respond with a GeoJSON if requested ([#171])
 - Add csv output to list-region cli ([#65])
 
 ### How to upgrade?
 
 - If you set up your own database you will need to rebuild the database or delete the results table (`DROP TABLE results;`).
+- If you used the API endpoint `/regions` be aware of the changed output format ([#171] [#195]). If you want to retrive a GeoJSON use the parameter `asGeoJSON=True`.
+
 [#65]: https://github.com/GIScience/ohsome-quality-analyst/issues/65
 [#99]: https://github.com/GIScience/ohsome-quality-analyst/issues/99
 [#102]: https://github.com/GIScience/ohsome-quality-analyst/pull/102
@@ -37,6 +39,7 @@
 [#168]: https://github.com/GIScience/ohsome-quality-analyst/pull/168
 [#171]: https://github.com/GIScience/ohsome-quality-analyst/issues/171
 [#179]: https://github.com/GIScience/ohsome-quality-analyst/pull/179
+[#179]: https://github.com/GIScience/ohsome-quality-analyst/pull/195
 [`pydantic`]: https://pydantic-docs.helpmanual.io/
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Save indicator as GeoJSON Feature to DB ([#149])
     - Extend database schema with one additional attribute `feature` of type JSON
-- API endpoint `/regions` responds with array of names and ids (default) or a GeoJSON if parameter `asGeoJSON=True` is set ([#171] [#195]).
+- API endpoint `/regions` responds with array of names and ids (default) or a GeoJSON if parameter `asGeoJSON=True` is set ([#171], [#195])
 
 ### New Features
 
@@ -27,7 +27,7 @@
 ### How to upgrade?
 
 - If you set up your own database you will need to rebuild the database or delete the results table (`DROP TABLE results;`).
-- If you used the API endpoint `/regions` be aware of the changed output format ([#171] [#195]). If you want to retrive a GeoJSON use the parameter `asGeoJSON=True`.
+- If you used the API endpoint `/regions` be aware of the changed output format ([#171], [#195]). If you want to retrive a GeoJSON use the parameter `asGeoJSON=True`.
 
 [#65]: https://github.com/GIScience/ohsome-quality-analyst/issues/65
 [#99]: https://github.com/GIScience/ohsome-quality-analyst/issues/99
@@ -39,7 +39,7 @@
 [#168]: https://github.com/GIScience/ohsome-quality-analyst/pull/168
 [#171]: https://github.com/GIScience/ohsome-quality-analyst/issues/171
 [#179]: https://github.com/GIScience/ohsome-quality-analyst/pull/179
-[#179]: https://github.com/GIScience/ohsome-quality-analyst/pull/195
+[#195]: https://github.com/GIScience/ohsome-quality-analyst/pull/195
 [`pydantic`]: https://pydantic-docs.helpmanual.io/
 
 

--- a/website/website/assets/js/map-en.js
+++ b/website/website/assets/js/map-en.js
@@ -13,7 +13,7 @@ function fetch_regions_from_server() {
 
 function fetch_regions_from_api() {
     // TODO: Add cache functionality
-    return fetch(apiUrl + '/regions')
+    return fetch(apiUrl + '/regions?asGeoJSON=True')
 }
 
 function status(response) {

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -240,8 +240,7 @@ async def get_available_regions(asGeoJSON: bool = False):
         regions = await db_client.get_regions_as_geojson()
         response.update(regions)
     else:
-        regions = await db_client.get_regions()
-        response["result"] = regions
+        response["result"] = await db_client.get_regions()
     return response
 
 

--- a/workers/ohsome_quality_analyst/geodatabase/client.py
+++ b/workers/ohsome_quality_analyst/geodatabase/client.py
@@ -195,14 +195,11 @@ async def get_regions_as_geojson() -> FeatureCollection:
     return feature_collection
 
 
-async def get_regions() -> List[tuple]:
+async def get_regions() -> List[dict]:
     query = "SELECT  name, ogc_fid FROM regions"
     async with get_connection() as conn:
-        record = await conn.fetch(query)
-    regions = []
-    for tuple_record in record:
-        regions.append(tuple(tuple_record))
-    return regions
+        records = await conn.fetch(query)
+    return [dict(r) for r in records]
 
 
 def sanity_check_dataset(dataset: str) -> bool:

--- a/workers/tests/integrationtests/test_api.py
+++ b/workers/tests/integrationtests/test_api.py
@@ -35,14 +35,16 @@ class TestApi(unittest.TestCase):
         response_content = json.loads(response.content)
         self.assertTrue(self.general_schema.is_valid(response_content))
         self.assertIsInstance(response_content["result"], list)
-        self.assertIsInstance(response_content["result"][0], dict)
+        for region in response_content["result"]:
+            self.assertIsInstance(region, dict)
 
         url = "/regions"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_content = json.loads(response.content)
         self.assertTrue(self.general_schema.is_valid(response_content))
-        self.assertIsInstance(response_content["result"][0], dict)
+        for region in response_content["result"]:
+            self.assertIsInstance(region, dict)
 
     def test_list_indicator_layer_combinations(self):
         url = "/indicatorLayerCombinations"

--- a/workers/tests/integrationtests/test_api.py
+++ b/workers/tests/integrationtests/test_api.py
@@ -28,18 +28,21 @@ class TestApi(unittest.TestCase):
         self.assertTrue(self.general_schema.is_valid(response_content))
         result = geojson.loads(json.dumps(response_content))
         self.assertTrue(result.is_valid)
+
         url = "/regions?asGeoJSON=false"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_content = json.loads(response.content)
         self.assertTrue(self.general_schema.is_valid(response_content))
         self.assertIsInstance(response_content["result"], list)
+        self.assertIsInstance(response_content["result"][0], dict)
+
         url = "/regions"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         response_content = json.loads(response.content)
         self.assertTrue(self.general_schema.is_valid(response_content))
-        self.assertIsInstance(response_content["result"], list)
+        self.assertIsInstance(response_content["result"][0], dict)
 
     def test_list_indicator_layer_combinations(self):
         url = "/indicatorLayerCombinations"

--- a/workers/tests/integrationtests/test_geodatabase.py
+++ b/workers/tests/integrationtests/test_geodatabase.py
@@ -111,6 +111,7 @@ class TestGeodatabase(unittest.TestCase):
     def test_get_regions(self):
         regions = asyncio.run(db_client.get_regions())
         self.assertIsInstance(regions, list)
+        self.assertIsInstance(regions[0], dict)
 
     def test_sanity_check_dataset(self):
         self.assertFalse(db_client.sanity_check_dataset("foo"))


### PR DESCRIPTION
### Description

- Update API endpoint for fetching regions in website source code.
- Rearrange CHANGELOG to reflect Breaking Changes.
- API endpoint regions will return a JSON array of key-value maps instead of an nested array. Values are names and identifiers of the regions.

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)