### PR TITLE
API: Change media type of GeoJSON response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Current Main
+
+### Other Changes
+
+- API: Change media type of GeoJSON response ([#199])
+
+[#199]: https://github.com/GIScience/ohsome-quality-analyst/pull/199
+
+
 ## 0.6.0
 
 ### Breaking Changes

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -3,7 +3,9 @@ from typing import Optional
 
 import pydantic
 from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from ohsome_quality_analyst import (
     __author__,
@@ -140,7 +142,9 @@ async def _fetch_indicator(
     )
     response = empty_api_response()
     response.update(geojson_object)
-    return response
+    return JSONResponse(
+        content=jsonable_encoder(response), media_type="application/geo+json"
+    )
 
 
 @app.get("/report/{name}")
@@ -205,7 +209,9 @@ async def _fetch_report(name: str, parameters: ReportRequestModel):
     )
     response = empty_api_response()
     response.update(geojson_object)
-    return response
+    return JSONResponse(
+        content=jsonable_encoder(response), media_type="application/geo+json"
+    )
 
 
 @app.get("/regions")
@@ -219,9 +225,12 @@ async def get_available_regions(asGeoJSON: bool = False):
     if asGeoJSON is True:
         regions = await db_client.get_regions_as_geojson()
         response.update(regions)
+        return JSONResponse(
+            content=jsonable_encoder(response), media_type="application/geo+json"
+        )
     else:
         response["result"] = await db_client.get_regions()
-    return response
+        return response
 
 
 @app.get("/indicatorLayerCombinations")

--- a/workers/tests/integrationtests/test_api_indicator.py
+++ b/workers/tests/integrationtests/test_api_indicator.py
@@ -31,6 +31,7 @@ class TestApiIndicator(unittest.TestCase):
 
     def run_tests(self, response) -> None:
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/geo+json")
         for schema in (self.general_schema, self.feature_schema):
             self.validate(response.json(), schema)
 

--- a/workers/tests/integrationtests/test_api_indicator_geojson_io.py
+++ b/workers/tests/integrationtests/test_api_indicator_geojson_io.py
@@ -39,6 +39,7 @@ class TestApiIndicatorIo(unittest.TestCase):
 
     def run_tests(self, response, schemata: Tuple[Schema]) -> None:
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/geo+json")
         for schema in schemata:
             self.validate(response.json(), schema)
 

--- a/workers/tests/integrationtests/test_api_report.py
+++ b/workers/tests/integrationtests/test_api_report.py
@@ -35,6 +35,7 @@ class TestApiReport(unittest.TestCase):
 
     def run_tests(self, response) -> None:
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/geo+json")
         response_content = geojson.loads(response.content)
         self.assertTrue(response_content.is_valid)  # Valid GeoJSON?
         self.assertTrue(self.general_schema.is_valid(response_content))

--- a/workers/tests/integrationtests/test_api_report_geojson_io.py
+++ b/workers/tests/integrationtests/test_api_report_geojson_io.py
@@ -46,6 +46,7 @@ class TestApiReportIo(unittest.TestCase):
 
     def run_tests(self, response) -> None:
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "application/geo+json")
 
         response_content = geojson.loads(response.content)
         self.assertTrue(response_content.is_valid)  # Valid GeoJSON?


### PR DESCRIPTION
### Description

The media type for GeoJSON text is "application/geo+json".

### Corresponding issue
Closes #133 

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)