### PR TITLE
Improvements to dev docs (minor)

### DIFF
--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -31,7 +31,14 @@ To reinitialize or update the database make sure to delete the volume and rebuil
 ```bash
 # Make sure that your git is up2date, e.g. git pull
 docker-compose -f docker-compose.development.yml down --remove-orphans --volumes
-docker-compose -f docker-compose.development.yml up -d --no-cache --force-recreate --build oqt-database
+docker-compose -f docker-compose.development.yml up -d --force-recreate --build oqt-database
+```
+
+To avoid using the cache of Docker run:
+
+```bash
+docker-compose -f docker-compose.development.yml build --no-cache
+docker-compose -f docker-compose.development.yml up -d
 ```
 
 > If for development purposes additional datasets are required please have a look at the scripts found in the `database/init_db.production` directory. For example to import the GHS POP dataset simply run the provided script (`database/init_db.production/GHS_POP.sh`). This will delete the existing GHS POP table (which covers only the custom regions), download the GHS POP dataset and import it into the database.


### PR DESCRIPTION
Remove `--no-cache` of docker-compose up command.
This flag works no longer. An alterntive is to use `docker-compose build` first and the run `docker-compose up`.