### PR TITLE
Remove layer definition "ideal_vgi_lulc"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Breaking Changes
+
+- Remove "IDEAL-VGI Land Use and Land Cover" as valid layer for the Mapping Saturation indicator ([#221])
+
+### How to upgrade
+
+- `ideal_vgi_lulc` is not a valid layer for the Mapping Saturation indicator anymore ([#221])
+
+[#221]: https://github.com/GIScience/ohsome-quality-analyst/pull/221
+
+
 ## 0.7.0
 
 ### Breaking Changes

--- a/workers/ohsome_quality_analyst/utils/definitions.py
+++ b/workers/ohsome_quality_analyst/utils/definitions.py
@@ -50,7 +50,6 @@ INDICATOR_LAYER = (
     ("MappingSaturation", "mapaction_rivers_length"),
     ("MappingSaturation", "ideal_vgi_infrastructure"),
     ("MappingSaturation", "ideal_vgi_poi"),
-    ("MappingSaturation", "ideal_vgi_lulc"),
     ("Currentness", "major_roads_count"),
     ("Currentness", "building_count"),
     ("Currentness", "amenities"),


### PR DESCRIPTION
### Description
Layer definition "IDEAL-VGI Land Use and Land Cover" has been a valid
layer in combination with the Mapping Saturation indicator.
But often time the area of the land-use gets smaller over time instead
of bigger, which makes it not suitable for the Mapping Saturation.
Beside that the Layer has not been used in any Report.


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
~- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing~
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
- [x] Decide on whether below mentioned alternatives would be better the solution proposed in this PR