### PR TITLE
Make `pydantic` data models more modular

### DIFF
--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -2,7 +2,7 @@ import fnmatch
 import logging
 from typing import Union
 
-from fastapi import Depends, FastAPI, Request, status
+from fastapi import Body, Depends, FastAPI, Request, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,10 +20,12 @@ from ohsome_quality_analyst import (
     oqt,
 )
 from ohsome_quality_analyst.api.request_models import (
-    IndicatorGETRequestModel,
-    IndicatorPOSTRequestModel,
-    ReportGETRequestModel,
-    ReportPOSTRequestModel,
+    INDICATOR_EXAMPLES,
+    REPORT_EXAMPLES,
+    IndicatorBpolys,
+    IndicatorDatabase,
+    ReportBpolys,
+    ReportDatabase,
 )
 from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.utils.definitions import (
@@ -117,8 +119,8 @@ def empty_api_response() -> dict:
 
 
 @app.get("/indicator")
-async def get_indicator(parameters=Depends(IndicatorGETRequestModel)):
-    """Get an already calculated Indicator for region defined by OQT.
+async def get_indicator(parameters=Depends(IndicatorDatabase)):
+    """Request an already calculated Indicator for an AOI defined by OQT.
 
     The response is a GeoJSON Feature with the indicator results as properties.
     To request an Indicator for a custom AOI please use the POST method.
@@ -127,8 +129,13 @@ async def get_indicator(parameters=Depends(IndicatorGETRequestModel)):
 
 
 @app.post("/indicator")
-async def post_indicator(parameters: IndicatorPOSTRequestModel):
-    """Create an Indicator.
+async def post_indicator(
+    parameters: Union[IndicatorBpolys, IndicatorDatabase] = Body(
+        ...,
+        examples=INDICATOR_EXAMPLES,
+    )
+):
+    """Request an Indicator for an AOI defined by OQT or a custom AOI.
 
     Either the parameters `dataset` and `featureId` have to be provided
     or the parameter `bpolys` in form of a GeoJSON.
@@ -167,8 +174,8 @@ async def _fetch_indicator(parameters) -> dict:
 
 
 @app.get("/report")
-async def get_report(parameters=Depends(ReportGETRequestModel)):
-    """Get an already calculated Report for region defined by OQT.
+async def get_report(parameters=Depends(ReportDatabase)):
+    """Request an already calculated Report for an AOI defined by OQT.
 
     The response is a GeoJSON Feature with the Report results as properties.
     To request an Report for a custom AOI pease use the POST method.
@@ -177,8 +184,13 @@ async def get_report(parameters=Depends(ReportGETRequestModel)):
 
 
 @app.post("/report")
-async def post_report(parameters: ReportPOSTRequestModel):
-    """Create a Report.
+async def post_report(
+    parameters: Union[ReportBpolys, ReportDatabase] = Body(
+        ...,
+        examples=REPORT_EXAMPLES,
+    )
+):
+    """Request a Report for an AOI defined by OQT or a custom AOI.
 
     Either the parameters `dataset` and `featureId` have to be provided
     or the parameter `bpolys` in form of a GeoJSON.

--- a/workers/ohsome_quality_analyst/api/request_models.py
+++ b/workers/ohsome_quality_analyst/api/request_models.py
@@ -8,9 +8,11 @@ information derived from `pydantic` models in the automatic generated API docume
 """
 
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import pydantic
+from geojson import Feature, FeatureCollection
+from pydantic import BaseModel
 
 from ohsome_quality_analyst.utils.definitions import (
     INDICATOR_LAYER,
@@ -29,7 +31,7 @@ DatasetEnum = Enum("DatasetNames", {name: name for name in get_dataset_names_api
 FidFieldEnum = Enum("FidFieldEnum", {name: name for name in get_fid_fields_api()})
 
 
-class BaseIndicatorModel(pydantic.BaseModel):
+class BaseIndicator(BaseModel):
     name: IndicatorEnum = pydantic.Field(
         ..., title="Indicator Name", example="GhsPopComparisonBuildings"
     )
@@ -57,9 +59,10 @@ class BaseIndicatorModel(pydantic.BaseModel):
 
         alias_generator = snake_to_lower_camel
         allow_mutation = False
+        extra = "forbid"
 
 
-class BaseReportModel(pydantic.BaseModel):
+class BaseReport(BaseModel):
     name: ReportEnum = pydantic.Field(..., title="Report Name", example="SimpleReport")
     include_svg: bool = False
 
@@ -68,39 +71,31 @@ class BaseReportModel(pydantic.BaseModel):
 
         alias_generator = snake_to_lower_camel
         allow_mutation = False
+        extra = "forbid"
 
 
-class BaseGETModel(pydantic.BaseModel):
-    dataset: DatasetEnum = pydantic.Field(..., title="Dataset Name", example="regions")
-    feature_id: str = pydantic.Field(..., title="Feature Id", example="3")
-    fid_field: Optional[FidFieldEnum]
+class BaseBpolys(BaseModel):
+    """Model for the `bpolys` parameter."""
 
-
-class BasePOSTModel(pydantic.BaseModel):
-    bpolys: Optional[dict]
-    dataset: Optional[DatasetEnum]
-    feature_id: Optional[str]
-    fid_field: Optional[FidFieldEnum]
-
-    @pydantic.root_validator(pre=True)
-    @classmethod
-    def check_bpolys_or_dataset_and_feature_id(cls, values):
-        """Make sure either bpolys or dataset and feature_id are given as parameters."""
-        # featureId is a pydantic alias for feature_id (See config class below)
-        _values = list(map(snake_to_lower_camel, values))
-        if (
-            "bpolys" in _values
-            and not any(v in _values for v in ("dataset", "featureId"))
-        ) or (
-            "bpolys" not in _values
-            and all(v in _values for v in ("dataset", "featureId"))
-        ):
-            return values
-        else:
-            raise ValueError(
-                "Request should contain either the parameter `bpolys` "
-                "or `dataset` and `featureId`."
-            )
+    bpolys: Union[Feature, FeatureCollection] = pydantic.Field(
+        ...,
+        title="bpolys",
+        example={
+            "type": "Feature",
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [8.674092292785645, 49.40427147224242],
+                        [8.695850372314453, 49.40427147224242],
+                        [8.695850372314453, 49.415552187316095],
+                        [8.674092292785645, 49.415552187316095],
+                        [8.674092292785645, 49.40427147224242],
+                    ]
+                ],
+            },
+        },
+    )
 
     @pydantic.validator("bpolys")
     @classmethod
@@ -112,51 +107,116 @@ class BasePOSTModel(pydantic.BaseModel):
             pass
         return value
 
-    class Config:
-        """Pydantic config class."""
 
-        alias_generator = snake_to_lower_camel
-        allow_mutation = False
-        fields = {
+class BaseDatabase(BaseModel):
+    """Model for the combination of parameters: `dataset`, `feature_id`, `fid_field`."""
+
+    dataset: DatasetEnum = pydantic.Field(..., title="Dataset Name", example="regions")
+    feature_id: str = pydantic.Field(..., title="Feature Id", example="3")
+    fid_field: Optional[FidFieldEnum]
+
+
+class IndicatorBpolys(BaseIndicator, BaseBpolys):
+    pass
+
+
+class IndicatorDatabase(BaseIndicator, BaseDatabase):
+    pass
+
+
+class ReportBpolys(BaseReport, BaseBpolys):
+    pass
+
+
+class ReportDatabase(BaseReport, BaseDatabase):
+    pass
+
+
+INDICATOR_EXAMPLES = {
+    "Custom AOI": {
+        "summary": "Request an Indicator for a custom AOI (`bpolys`).",
+        "description": (
+            "The parameter `bpolys` has to be a valid GeoJSON Feature or "
+            "FeatureCollection object. The Geometry of those objects has to be Polygon "
+            "or MultiPolygon. "
+        ),
+        "value": {
+            "name": "GhsPopComparisonBuildings",
+            "layer_name": "building_count",
             "bpolys": {
-                "title": "Bounding Polygons",
-                "description": (
-                    "A GeoJSON Geometry, Feature or FeatureCollection. "
-                    + "Geometry type must be Polygon or MultiPolygon."
-                ),
-                "example": {
-                    "type": "Feature",
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [
-                            [
-                                [8.674092292785645, 49.40427147224242],
-                                [8.695850372314453, 49.40427147224242],
-                                [8.695850372314453, 49.415552187316095],
-                                [8.674092292785645, 49.415552187316095],
-                                [8.674092292785645, 49.40427147224242],
-                            ]
-                        ],
-                    },
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [8.674092292785645, 49.40427147224242],
+                            [8.695850372314453, 49.40427147224242],
+                            [8.695850372314453, 49.415552187316095],
+                            [8.674092292785645, 49.415552187316095],
+                            [8.674092292785645, 49.40427147224242],
+                        ]
+                    ],
                 },
             },
-            "dataset": {"title": "Dataset Name", "example": "regions"},
-            "feature_id": {"title": "Feature Id", "example": "3"},
-            "fid_field": {"title": "Feature Id Field", "example": "ogc_fid"},
-        }
+        },
+    },
+    "OQT AOI": {
+        "summary": (
+            "Request an Indicator for an AOI defined by OQT (`dataset` and "
+            "`feature_id`)."
+        ),
+        "description": (
+            "Specify `dataset` and `feature_id` to request an already calculated "
+            "indicator for an AOI defined by OQT."
+        ),
+        "value": {
+            "name": "GhsPopComparisonBuildings",
+            "layer_name": "building_count",
+            "dataset": "regions",
+            "feature_id": 3,
+        },
+    },
+}
 
-
-class IndicatorGETRequestModel(BaseGETModel, BaseIndicatorModel):
-    pass
-
-
-class IndicatorPOSTRequestModel(BasePOSTModel, BaseIndicatorModel):
-    pass
-
-
-class ReportGETRequestModel(BaseGETModel, BaseReportModel):
-    pass
-
-
-class ReportPOSTRequestModel(BasePOSTModel, BaseReportModel):
-    pass
+REPORT_EXAMPLES = {
+    "Custom AOI": {
+        "summary": "Request a Report for a custom AOI (`bpolys`).",
+        "description": (
+            "The parameter `bpolys` has to be a valid GeoJSON Feature or "
+            "FeatureCollection object. The Geometry of those objects has to be Polygon "
+            "or MultiPolygon. "
+        ),
+        "value": {
+            "name": "SimpleReport",
+            "bpolys": {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [8.674092292785645, 49.40427147224242],
+                            [8.695850372314453, 49.40427147224242],
+                            [8.695850372314453, 49.415552187316095],
+                            [8.674092292785645, 49.415552187316095],
+                            [8.674092292785645, 49.40427147224242],
+                        ]
+                    ],
+                },
+            },
+        },
+    },
+    "OQT AOI": {
+        "summary": (
+            "Request a Report for a AOI defined by OQT (`dataset` and `feature_id`)."
+        ),
+        "description": (
+            "Specify `dataset` and `feature_id` to request an already calculated "
+            "Report for an AOI defined by OQT."
+        ),
+        "value": {
+            "name": "SimpleReport",
+            "dataset": "regions",
+            "feature_id": 3,
+        },
+    },
+}

--- a/workers/tests/unittests/test_api_request_models.py
+++ b/workers/tests/unittests/test_api_request_models.py
@@ -19,7 +19,7 @@ class TestApiRequestModels(unittest.TestCase):
             self.bpolys = json.load(file)
 
     def test_bpolys_valid(self):
-        request_models.BasePOSTModel(bpolys=self.bpolys)
+        request_models.BaseBpolys(bpolys=self.bpolys)
 
     def test_bpolys_invalid(self):
         bpolys = Polygon(
@@ -27,51 +27,97 @@ class TestApiRequestModels(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
-            request_models.BasePOSTModel(bpolys=bpolys)
+            request_models.BaseBpolys(bpolys=bpolys)
 
     def test_dataset_valid(self):
-        request_models.BasePOSTModel(dataset="regions", feature_id="3")
-        request_models.BasePOSTModel(
+        request_models.BaseDatabase(dataset="regions", feature_id="3")
+        request_models.BaseDatabase(
             dataset="regions", feature_id="3", fid_field="ogc_fid"
         )
-        request_models.BaseGETModel(dataset="regions", feature_id="3")
-        request_models.BaseGETModel(
+        request_models.BaseDatabase(dataset="regions", feature_id="3")
+        request_models.BaseDatabase(
             dataset="regions", feature_id="3", fid_field="ogc_fid"
         )
 
     def test_dataset_invalid(self):
         with self.assertRaises(ValueError):
-            request_models.BasePOSTModel(dataset="foo", feature_id="3")
+            request_models.BaseDatabase(dataset="foo", feature_id="3")
         with self.assertRaises(ValueError):
-            request_models.BaseGETModel(dataset="foo", feature_id="3")
+            request_models.BaseDatabase(dataset="foo", feature_id="3")
 
-    def test_invalid_set_of_arguments(self):
-        with self.assertRaises(ValueError):
-            request_models.BasePOSTModel(
-                bpolys=self.bpolys, dataset="regions", feature_id="3"
-            )
-        with self.assertRaises(ValueError):
-            request_models.BasePOSTModel(dataset="regions")
-        with self.assertRaises(ValueError):
-            request_models.BaseGETModel(dataset="regions")
-        with self.assertRaises(ValueError):
-            request_models.BasePOSTModel(feature_id="3")
-        with self.assertRaises(ValueError):
-            request_models.BaseGETModel(feature_id="3")
-        with self.assertRaises(ValueError):
-            request_models.BaseIndicatorModel(name="GhsPopComparisonBuildings")
-        with self.assertRaises(ValueError):
-            request_models.BaseIndicatorModel(layer_name="building_count")
-
-    def test_valid_indicator_layer_combination(self):
-        request_models.BaseIndicatorModel(
+    def test_valid_layer(self):
+        request_models.BaseIndicator(
             name="GhsPopComparisonBuildings",
             layerName="building_count",
         )
 
+    def test_invalid_layer(self):
+        with self.assertRaises(ValueError):
+            request_models.BaseIndicator(
+                name="GhsPopComparisonBuildings",
+                layerName="foo",
+            )
+
     def test_invalid_indicator_layer_combination(self):
         with self.assertRaises(ValueError):
-            request_models.BaseIndicatorModel(
+            request_models.BaseIndicator(
                 name="GhsPopComparisonBuildings",
                 layerName="amenities",
             )
+
+    def test_indicator_database(self):
+        request_models.IndicatorDatabase(
+            name="GhsPopComparisonBuildings",
+            layerName="building_count",
+            dataset="regions",
+            featureId="3",
+        )
+        request_models.IndicatorDatabase(
+            name="GhsPopComparisonBuildings",
+            layerName="building_count",
+            dataset="regions",
+            featureId="Heidelberg",
+            fidField="name",
+        )
+
+    def test_indicator_bpolys(self):
+        request_models.IndicatorBpolys(
+            name="GhsPopComparisonBuildings",
+            layerName="building_count",
+            bpolys=self.bpolys,
+        )
+
+    def test_invalid_set_of_arguments(self):
+        # TODO: Write logic to test any combination of invalid parameters
+        # Write down valid combination and derive invalid from those.
+        models = (request_models.IndicatorBpolys, request_models.IndicatorDatabase)
+        for model in models:
+            with self.assertRaises(ValueError):
+                model(name="GhsPopComparisonBuildings")
+            with self.assertRaises(ValueError):
+                model(layerName="building_count")
+            with self.assertRaises(ValueError):
+                model(dataset="regions")
+            with self.assertRaises(ValueError):
+                model(featureId="3")
+            with self.assertRaises(ValueError):
+                model(
+                    name="GhsPopComparisonBuildings",
+                    layerName="building_count",
+                    dataset="regions",
+                )
+            with self.assertRaises(ValueError):
+                model(
+                    name="GhsPopComparisonBuildings",
+                    layerName="building_count",
+                    bpolys=self.bpolys,
+                    dataset="regions",
+                )
+            with self.assertRaises(ValueError):
+                model(
+                    name="GhsPopComparisonBuildings",
+                    layerName="building_count",
+                    bpolys=self.bpolys,
+                    dataset="regions",
+                    featureId="3",
+                )


### PR DESCRIPTION
### Description

Pydantic data-models: Make models more modular. Use `Union` for those models when definining FastAPI request parameters.

FastAPIs swagger interface: Add multiple examples and improve documentation/description of those examples and endpoints in gerneral.

### Checklist
- [ ] I have updated my branch to `main` (e.g. through `git rebase main`)
- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
    - [ ]  Test for *all* invalid parameter combination
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)