### PR TITLE
Make flatten of Feature Properties optional

### DIFF
--- a/workers/ohsome_quality_analyst/base/report.py
+++ b/workers/ohsome_quality_analyst/base/report.py
@@ -72,7 +72,7 @@ class BaseReport(metaclass=ABCMeta):
         report_properties["metadata"].pop("label_description", None)
         properties = flatten_dict(report_properties, prefix="report")
         for i, indicator in enumerate(self.indicators):
-            p = indicator.as_feature()["properties"]
+            p = indicator.as_feature(flatten=True)["properties"]
             properties.update(
                 {"indicators." + str(i) + "." + str(key): val for key, val in p.items()}
             )

--- a/workers/ohsome_quality_analyst/geodatabase/client.py
+++ b/workers/ohsome_quality_analyst/geodatabase/client.py
@@ -25,10 +25,7 @@ import geojson
 from geojson import Feature, FeatureCollection, MultiPolygon, Polygon
 
 from ohsome_quality_analyst.utils.definitions import DATASETS
-from ohsome_quality_analyst.utils.helper import (
-    datetime_to_isostring_timestamp,
-    unflatten_dict,
-)
+from ohsome_quality_analyst.utils.helper import datetime_to_isostring_timestamp
 
 
 @asynccontextmanager
@@ -119,11 +116,9 @@ async def load_indicator_results(indicator, dataset: str, feature_id: str) -> bo
     indicator.result.description = query_result["result_description"]
     indicator.result.svg = query_result["result_svg"]
 
+    # Write data back to the attributes of the indicator object
     feature = geojson.loads(query_result["feature"])
-    properties = unflatten_dict(feature["properties"])
-    result_data = properties["data"]
-
-    for key, value in result_data.items():
+    for key, value in feature["properties"]["data"].items():
         setattr(indicator, key, value)
     return True
 

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -51,7 +51,7 @@ async def create_indicator_as_geojson(
                 fid_field,
                 force,
             )
-            features.append(indicator.as_feature())
+            features.append(indicator.as_feature(flatten=True))
         if len(features) == 1:
             return features[0]
         else:
@@ -67,7 +67,7 @@ async def create_indicator_as_geojson(
             fid_field,
             force,
         )
-        return indicator.as_feature()
+        return indicator.as_feature(flatten=True)
 
 
 async def create_report_as_geojson(

--- a/workers/ohsome_quality_analyst/utils/helper.py
+++ b/workers/ohsome_quality_analyst/utils/helper.py
@@ -125,10 +125,10 @@ def flatten_dict(input_: dict, *, separator: str = ".", prefix: str = "") -> dic
     if isinstance(input_, dict):
         if prefix != "":
             prefix += separator
-        for key, _ in input_.items():
+        for key, val in input_.items():
             output.update(
                 flatten_dict(
-                    input_[key],
+                    val,
                     separator=separator,
                     prefix=prefix + key,
                 ),

--- a/workers/ohsome_quality_analyst/utils/helper.py
+++ b/workers/ohsome_quality_analyst/utils/helper.py
@@ -115,19 +115,33 @@ def loads_geojson(bpolys: dict) -> Generator[Feature, None, None]:
         )
 
 
-def flatten_dict(input_dict: dict, *, separator: str = ".", prefix: str = "") -> dict:
-    """Returns the given dict as flattened one-level dict."""
-    if isinstance(input_dict, dict):
-        output = {}
+def flatten_dict(input_: dict, *, separator: str = ".", prefix: str = "") -> dict:
+    """Return the given dictionary as flattened one-level dict.
+
+    If the given dictionary contains a list it will be flattened as well.
+    For each element of the list the index of this element will be part of the key.
+    """
+    output = {}
+    if isinstance(input_, dict):
         if prefix != "":
             prefix += separator
-        for key, value in input_dict.items():
+        for key, _ in input_.items():
             output.update(
-                flatten_dict(input_dict[key], separator=separator, prefix=prefix + key)
+                flatten_dict(
+                    input_[key],
+                    separator=separator,
+                    prefix=prefix + key,
+                ),
+            )
+        return output
+    elif isinstance(input_, list):
+        for i, item in enumerate(input_):
+            output.update(
+                flatten_dict({str(i): item}, separator=separator, prefix=prefix),
             )
         return output
     else:
-        return {prefix: input_dict}
+        return {prefix: input_}
 
 
 def unflatten_dict(input_dict: dict, *, separator: str = "."):

--- a/workers/ohsome_quality_analyst/utils/helper.py
+++ b/workers/ohsome_quality_analyst/utils/helper.py
@@ -144,31 +144,6 @@ def flatten_dict(input_: dict, *, separator: str = ".", prefix: str = "") -> dic
         return {prefix: input_}
 
 
-def unflatten_dict(input_dict: dict, *, separator: str = "."):
-    """Returns the given one-level dict as unflatten dict."""
-    output_dict = {}
-    for k, v in input_dict.items():
-        keys = k.split(separator)
-        temp_dict = {}
-        for i, key in enumerate(reversed(keys)):
-            if i == 0:
-                temp_dict = {key: v}
-            else:
-                temp_dict = {key: temp_dict}
-        output_dict = merge_dicts(output_dict, temp_dict)
-    return output_dict
-
-
-def merge_dicts(dict1, dict2):
-    """Merges two nested dictionaries."""
-    for key in dict2:
-        if key in dict1:
-            merge_dicts(dict1[key], dict2[key])
-        else:
-            dict1[key] = dict2[key]
-    return dict1
-
-
 def flatten_sequence(input_seq: Union[dict, list, tuple, set]) -> list:
     """Returns the given input sequence as a list.
 

--- a/workers/tests/integrationtests/test_base_indicator.py
+++ b/workers/tests/integrationtests/test_base_indicator.py
@@ -8,15 +8,33 @@ from ohsome_quality_analyst.indicators.ghs_pop_comparison_buildings.indicator im
 
 
 class TestBaseIndicator(unittest.TestCase):
-    def test_as_feature(self):
-        feature = asyncio.run(
+    def setUp(self):
+        self.feature = asyncio.run(
             db_client.get_feature_from_db(dataset="regions", feature_id="3")
         )
+        self.layer_name = "building_count"
+
+    def test_as_feature(self):
         indicator = GhsPopComparisonBuildings(
-            feature=feature, layer_name="building_count"
+            feature=self.feature, layer_name=self.layer_name
         )
 
         feature = indicator.as_feature()
+        self.assertTrue(feature.is_valid)
+        for i in (
+            "pop_count",
+            "area",
+            "pop_count_per_sqkm",
+            "feature_count",
+            "feature_count_per_sqkm",
+        ):
+            self.assertIn(i, feature["properties"]["data"].keys())
+
+    def test_as_feature_flatten(self):
+        indicator = GhsPopComparisonBuildings(
+            feature=self.feature, layer_name=self.layer_name
+        )
+        feature = indicator.as_feature(flatten=True)
         self.assertTrue(feature.is_valid)
         for i in (
             "data.pop_count",
@@ -28,11 +46,8 @@ class TestBaseIndicator(unittest.TestCase):
             self.assertIn(i, feature["properties"].keys())
 
     def test_data_property(self):
-        feature = asyncio.run(
-            db_client.get_feature_from_db(dataset="regions", feature_id="3")
-        )
         indicator = GhsPopComparisonBuildings(
-            feature=feature, layer_name="building_count"
+            feature=self.feature, layer_name=self.layer_name
         )
         self.assertIsNotNone(indicator.data)
         for key in indicator.data.keys():

--- a/workers/tests/unittests/test_helper.py
+++ b/workers/tests/unittests/test_helper.py
@@ -15,9 +15,7 @@ from ohsome_quality_analyst.utils.helper import (
     flatten_sequence,
     load_sklearn_model,
     loads_geojson,
-    merge_dicts,
     name_to_class,
-    unflatten_dict,
 )
 
 
@@ -146,17 +144,6 @@ class TestHelper(unittest.TestCase):
             "something": 5,
         }
         self.assertDictEqual(flatten_dict(deep), flat)
-
-    def test_unflatten_dict(self):
-        flat = {"foo.bar": "baz", "foo.lang.нет": "tak", "something": 5}
-        deep = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}
-        self.assertDictEqual(unflatten_dict(flat), deep)
-
-    def test_merge_dicts(self):
-        dict1 = {"foo": {"bar": "baz"}}
-        dict2 = {"foo": {"lang": {"нет": "tak"}}, "something": 5}
-        merged_dict = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}
-        self.assertDictEqual(merge_dicts(dict1, dict2), merged_dict)
 
     # TODO: add tests for other input than dict
     def test_flatten_seq(self):

--- a/workers/tests/unittests/test_helper.py
+++ b/workers/tests/unittests/test_helper.py
@@ -87,6 +87,66 @@ class TestHelper(unittest.TestCase):
         flat = {"foo.bar": "baz", "foo.lang.нет": "tak", "something": 5}
         self.assertDictEqual(flatten_dict(deep), flat)
 
+    def test_flatten_dict_list(self):
+        deep = {"foo": {"bar": "baz", "lang": {"нет": ["tak", "tak2"]}}, "something": 5}
+        flat = {
+            "foo.bar": "baz",
+            "foo.lang.нет.0": "tak",
+            "foo.lang.нет.1": "tak2",
+            "something": 5,
+        }
+        self.assertDictEqual(flatten_dict(deep), flat)
+
+    def test_flatten_dict_list_nested(self):
+        deep = {
+            "foo": {
+                "bar": "baz",
+                "lang": {
+                    "нет": [
+                        {"tak": {"taktak": "taktaktak"}},
+                        {"tok": {"toktok": "toktoktok"}},
+                    ]
+                },
+            },
+            "something": 5,
+        }
+        flat = {
+            "foo.bar": "baz",
+            "foo.lang.нет.0.tak.taktak": "taktaktak",
+            "foo.lang.нет.1.tok.toktok": "toktoktok",
+            "something": 5,
+        }
+        self.assertDictEqual(flatten_dict(deep), flat)
+
+    def test_flatten_dict_list_nested_2(self):
+        deep = {
+            "foo": {
+                "bar": "baz",
+                "lang": {
+                    "нет": [
+                        [
+                            {"tak": "taktak"},
+                            {"tok": "toktok"},
+                        ],
+                        [
+                            {"tak2": "taktak2"},
+                            {"tok2": "toktok2"},
+                        ],
+                    ]
+                },
+            },
+            "something": 5,
+        }
+        flat = {
+            "foo.bar": "baz",
+            "foo.lang.нет.0.0.tak": "taktak",
+            "foo.lang.нет.0.1.tok": "toktok",
+            "foo.lang.нет.1.0.tak2": "taktak2",
+            "foo.lang.нет.1.1.tok2": "toktok2",
+            "something": 5,
+        }
+        self.assertDictEqual(flatten_dict(deep), flat)
+
     def test_unflatten_dict(self):
         flat = {"foo.bar": "baz", "foo.lang.нет": "tak", "something": 5}
         deep = {"foo": {"bar": "baz", "lang": {"нет": "tak"}}, "something": 5}


### PR DESCRIPTION
### Description

Supported nested lists for func `flatten_dict`.

Make flatten of Feature Properties optional.
This will make unflatten function obsolete. This function has been used
to "unflatten" the Feature Properties after loading them from the
database. Now the Feature will be stored to the database in "unflattend"
form.

Remove obsolete function `unflatten_dict`.

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- ~~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~~
- [x] Check unflatten function of the website (`utils.js`) for compability to changes introduced in this PR (list are now flattend)
  - Should it be possible to make an request to the API for an unflattend response? 
