### PR TITLE
Fix and improve CLI command `create_all_indicators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@
 - Utilize `singledispatch` for `create_indicator` function of the `oqt` module ([#239])
 - Add `landmarks` layer [#246])
 - Add SHDI to database and add functionality to get SHDI for an AOI by intersection using SQL ([#266])
+- Support any dataset, not just "regions" for CLI function `create_all_indicators` ([#254])
+- Fix concurrent execution of CLI function `create_all_indicators` using async and semaphores ([#254])
+- Support choosing a single indicator and/or single layer for CLI command `create_all_indicators` ([#254])
 
 [#221]: https://github.com/GIScience/ohsome-quality-analyst/pull/221
 [#227]: https://github.com/GIScience/ohsome-quality-analyst/pull/227
 [#239]: https://github.com/GIScience/ohsome-quality-analyst/pull/239
 [#246]: https://github.com/GIScience/ohsome-quality-analyst/pull/246
+[#254]: https://github.com/GIScience/ohsome-quality-analyst/pull/254
 [#266]: https://github.com/GIScience/ohsome-quality-analyst/pull/266
 [`rasterstats`]: https://github.com/perrygeo/python-rasterstats
 [`openpoiservice`]: https://github.com/GIScience/openpoiservice

--- a/workers/ohsome_quality_analyst/cli/cli.py
+++ b/workers/ohsome_quality_analyst/cli/cli.py
@@ -199,19 +199,21 @@ def create_report(
 
 
 @cli.command("create-all-indicators")
+@cli_option(options.dataset_name)
 @cli_option(options.force)
-def create_all_indicators(force: bool):
-    """Create all indicators for all OQT regions."""
+def create_all_indicators(dataset_name: str, force: bool):
+    """Create all indicators for all features of the given dataset."""
     click.echo(
-        "This command will calculate all indicators for all OQT regions "
-        + "and may take a while to complete."
+        "This command will calculate all indicators for all features of the given "
+        + "dataset. This may take a while to complete."
     )
     if force:
         click.echo(
-            "The argument 'force' will update the indicator results in the database."
+            "The argument 'force' will overwrite existing indicator results in the "
+            + "database."
         )
     click.confirm("Do you want to continue?", abort=True)
-    asyncio.run(oqt.create_all_indicators(force=force))
+    asyncio.run(oqt.create_all_indicators(dataset_name, force=force))
 
 
 if __name__ == "__main__":

--- a/workers/ohsome_quality_analyst/cli/cli.py
+++ b/workers/ohsome_quality_analyst/cli/cli.py
@@ -199,10 +199,52 @@ def create_report(
 
 
 @cli.command("create-all-indicators")
-@cli_option(options.dataset_name)
+@click.option(
+    "--dataset-name",
+    "-d",
+    required=True,
+    type=click.Choice(
+        DATASETS.keys(),
+        case_sensitive=True,
+    ),
+    help=("Choose a dataset containing geometries."),
+)
+@click.option(
+    "--indicator-name",
+    "-i",
+    type=click.Choice(
+        load_metadata("indicators").keys(),
+        case_sensitive=True,
+    ),
+    help="Choose an indicator,valid indicators are specified in definitions.py .",
+    default=None,
+)
+@click.option(
+    "--layer-name",
+    "-l",
+    type=click.Choice(
+        list(load_layer_definitions().keys()),
+        case_sensitive=True,
+    ),
+    help=(
+        "Choose a layer. This defines which OSM features will be considered "
+        "in the quality analysis."
+    ),
+    default=None,
+)
 @cli_option(options.force)
-def create_all_indicators(dataset_name: str, force: bool):
-    """Create all indicators for all features of the given dataset."""
+def create_all_indicators(
+    dataset_name: str,
+    indicator_name: str,
+    layer_name: str,
+    force: bool,
+):
+    """Create all Indicators for all features of the given dataset.
+
+    The default is to create all Indicator/Layer combinations for all features of the
+    given dataset. This can be restricted to one Indicator type and/or one Layer
+    definition by providing the corresponding options.
+    """
     click.echo(
         "This command will calculate all indicators for all features of the given "
         + "dataset. This may take a while to complete."
@@ -213,7 +255,14 @@ def create_all_indicators(dataset_name: str, force: bool):
             + "database."
         )
     click.confirm("Do you want to continue?", abort=True)
-    asyncio.run(oqt.create_all_indicators(dataset_name, force=force))
+    asyncio.run(
+        oqt.create_all_indicators(
+            dataset_name,
+            indicator_name,
+            layer_name,
+            force=force,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/workers/ohsome_quality_analyst/cli/cli.py
+++ b/workers/ohsome_quality_analyst/cli/cli.py
@@ -258,8 +258,8 @@ def create_all_indicators(
     asyncio.run(
         oqt.create_all_indicators(
             dataset_name,
-            indicator_name,
-            layer_name,
+            indicator_name=indicator_name,
+            layer_name=layer_name,
             force=force,
         )
     )

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -251,7 +251,6 @@ async def _create_report(  # noqa
 ) -> Report:
     """Create a Report.
 
-    Create indicators from scratch.
     Aggregates all indicator results and calculates an overall quality score.
     """
     name, feature = (
@@ -279,11 +278,12 @@ async def _create_report(  # noqa
     return report
 
 
-async def create_all_indicators(force: bool = False) -> None:
-    """Create all Indicator/Layer combinations for OQT regions.
+async def create_all_indicators(dataset: str, force: bool = False) -> None:
+    """Create all indicator/layer combination for the given dataset.
 
     Possible Indicator/Layer combinations are defined in `definitions.py`.
     This functions executes `create_indicator()` function up to four times concurrently.
+
     """
 
     async def _create_indicator(indicator_name, layer_name, fid, force, semaphore):
@@ -301,7 +301,7 @@ async def create_all_indicators(force: bool = False) -> None:
     # Semaphore limits num of concurrent executions
     semaphore = asyncio.Semaphore(4)
     tasks: List[asyncio.Task] = []
-    fids = await db_client.get_feature_ids("regions")
+    fids = await db_client.get_feature_ids(dataset)
     for fid in fids:
         for indicator_name, layer_name in INDICATOR_LAYER:
             tasks.append(

--- a/workers/ohsome_quality_analyst/utils/definitions.py
+++ b/workers/ohsome_quality_analyst/utils/definitions.py
@@ -353,3 +353,13 @@ def get_attribution(data_keys: list) -> str:
     assert set(data_keys) <= set(("OSM", "GHSL", "VNL"))
     filtered = dict(filter(lambda d: d[0] in data_keys, ATTRIBUTION_TEXTS.items()))
     return "; ".join([str(v) for v in filtered.values()])
+
+
+def get_valid_layers(indcator_name: str) -> tuple:
+    """Get valid Indicator/Layer combination of an Indicator."""
+    return tuple([tup[1] for tup in INDICATOR_LAYER if tup[0] == indcator_name])
+
+
+def get_valid_indicators(layer_name: str) -> tuple:
+    """Get valid Indicator/Layer combination of a Layer."""
+    return tuple([tup[0] for tup in INDICATOR_LAYER if tup[1] == layer_name])

--- a/workers/tests/integrationtests/test_oqt.py
+++ b/workers/tests/integrationtests/test_oqt.py
@@ -146,7 +146,13 @@ class TestOqt(unittest.TestCase):
             new_callable=AsyncMock,
         ) as get_feature_ids_mock:
             get_feature_ids_mock.return_value = ["3"]
-            asyncio.run(oqt.create_all_indicators("regions"))
+            asyncio.run(
+                oqt.create_all_indicators(
+                    dataset="regions",
+                    indicator_name="GhsPopComparisonBuildings",
+                    layer_name="building_count",
+                )
+            )
 
     def test_check_area_size(self):
         path = os.path.join(

--- a/workers/tests/integrationtests/test_oqt.py
+++ b/workers/tests/integrationtests/test_oqt.py
@@ -146,7 +146,7 @@ class TestOqt(unittest.TestCase):
             new_callable=AsyncMock,
         ) as get_feature_ids_mock:
             get_feature_ids_mock.return_value = ["3"]
-            asyncio.run(oqt.create_all_indicators(dataset="regions"))
+            asyncio.run(oqt.create_all_indicators("regions"))
 
     def test_check_area_size(self):
         path = os.path.join(

--- a/workers/tests/integrationtests/test_oqt.py
+++ b/workers/tests/integrationtests/test_oqt.py
@@ -146,7 +146,7 @@ class TestOqt(unittest.TestCase):
             new_callable=AsyncMock,
         ) as get_feature_ids_mock:
             get_feature_ids_mock.return_value = ["3"]
-            asyncio.run(oqt.create_all_indicators())
+            asyncio.run(oqt.create_all_indicators(dataset="regions"))
 
     def test_check_area_size(self):
         path = os.path.join(

--- a/workers/tests/unittests/test_cli.py
+++ b/workers/tests/unittests/test_cli.py
@@ -5,6 +5,7 @@ https://click.palletsprojects.com/en/7.x/testing/?highlight=testing
 
 import os
 import unittest
+from unittest import mock
 
 from click.testing import CliRunner
 
@@ -47,13 +48,64 @@ class TestCliUnit(unittest.TestCase):
         result = self.runner.invoke(cli, ["create-indicator", "--help"])
         assert result.exit_code == 0
 
-    def test_create_all_indicators(self):
+    @mock.patch("ohsome_quality_analyst.oqt.create_indicator")
+    def test_create_all_indicators_invlid_opts(self, mo):
         result = self.runner.invoke(
             cli,
             ["create-all-indicators"],
-            input="N\n",
         )
-        assert result.exit_code == 1
+        assert result.exit_code == 2
+
+    @mock.patch("ohsome_quality_analyst.oqt.create_indicator", mock.AsyncMock())
+    def test_create_all_indicators_valid_opts(self):
+        result = self.runner.invoke(
+            cli,
+            [
+                "create-all-indicators",
+                "-d",
+                "regions",
+            ],
+            input="Y\n",
+        )
+        assert result.exit_code == 0
+        result = self.runner.invoke(
+            cli,
+            [
+                "create-all-indicators",
+                "-d",
+                "regions",
+                "-l",
+                "building_count",
+            ],
+            input="Y\n",
+        )
+        assert result.exit_code == 0
+        result = self.runner.invoke(
+            cli,
+            [
+                "create-all-indicators",
+                "-d",
+                "regions",
+                "-i",
+                "GhsPopComparisonBuildings",
+            ],
+            input="Y\n",
+        )
+        assert result.exit_code == 0
+        result = self.runner.invoke(
+            cli,
+            [
+                "create-all-indicators",
+                "-d",
+                "regions",
+                "-i",
+                "GhsPopComparisonBuildings",
+                "-l",
+                "building_count",
+            ],
+            input="Y\n",
+        )
+        assert result.exit_code == 0
 
 
 if __name__ == "__main__":

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -123,3 +123,24 @@ class TestDefinitions(unittest.TestCase):
         )
 
         self.assertRaises(AssertionError, definitions.get_attribution, ["MSO"])
+
+    def test_get_valid_indicators(self):
+        indicators = definitions.get_valid_indicators("building_count")
+        self.assertEqual(
+            indicators,
+            (
+                "GhsPopComparisonBuildings",
+                "MappingSaturation",
+                "Currentness",
+            ),
+        )
+
+    def test_get_valid_layers(self):
+        layers = definitions.get_valid_layers("GhsPopComparisonRoads")
+        self.assertEqual(
+            layers,
+            (
+                "jrc_road_length",
+                "major_roads_length",
+            ),
+        )


### PR DESCRIPTION
### Description

- Support any dataset, not just "regions" for the CLI function `create_all_indicators`.
- Fix concurrent execution of `create_all_indicators` using async and semaphores. (See description of the problem below)
- Add support of single indicator and/or single layer to the CLI command `create_all_indicators`.

Somehow during creation of the async tasks they got duplicated (same function with same parameter values), which resulted in creating the same indicator multiply times. This ended quickly in a write error to the database.

```
Usage: oqt create-all-indicators [OPTIONS]

  Create all Indicators for all features of the given dataset.

  The default is to create all Indicator/Layer combinations for all features
  of the given dataset. This can be restricted to one Indicator type and/or
  one Layer definition by providing the corresponding options.

Options:
  -d, --dataset-name [regions|gadm]
                                  Choose a dataset containing geometries.
                                  [required]

  -i, --indicator-name [GhsPopComparisonBuildings|GhsPopComparisonRoads|MappingSaturation|PoiDensity|TagsRatio|Currentness]
                                  Choose an indicator,valid indicators are
                                  specified in definitions.py .

  -l, --layer-name [building_count|building_area|major_roads_count|major_roads_length|amenities|poi|jrc_health_count|jrc_education_count|jrc_road_length|jrc_road_count|jrc_railway_length|jrc_railway_count|jrc_airport_count|jrc_water_treatment_plant_count|jrc_power_generation_plant_count|jrc_cultural_heritage_site_count|jrc_bridge_count|jrc_mass_gathering_sites_count|mapaction_settlements_count|mapaction_capital_city_count|mapaction_rail_length|mapaction_major_roads_length|mapaction_lakes_count|mapaction_lakes_area|mapaction_rivers_length|ideal_vgi_infrastructure|ideal_vgi_poi|ideal_vgi_lulc]
                                  Choose a layer. This defines which OSM
                                  features will be considered in the quality
                                  analysis.

  --force                         Force recreation of indicator. This will
                                  update the results of an indicator in the
                                  database.

  --help                          Show this message and exit.
  ```



### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
- [x] Fix tests
- [x] Waiting for #271 to fix Layer Definition name issue