### PR TITLE
Configure OQT using files or environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,9 +140,12 @@ cython_debug/
 # Pycharm
 .idea/
 
-# Custom
+# OQT
 website/website/assets/data/regions.geojson
 database/init_db.production/regions.geojson
 database/scripts/schema.test.sql
 database/scripts/schema.dev.sql.gz
 data/
+workers/config/*
+!workers/config/sample.config.yaml
+!workers/config/logging.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking Changes
 
+- Rename environment variable `OHSOME_API` to `OQT_OHSOME_API` ([#255])
+
+### Bug Fixes
+
 - Make inclusion of indicator data in response optional ([#370])
 - Per default properties of the GeoJSON response are not flat ([#375])
 - Remove project specific reports `JrcRequirements`, `SketchmapFitness`, and `MapActionPoc` from the website ([#382])
@@ -15,6 +19,7 @@
 - Add new representative report `RoadReport` ([#357])
 - Add new representative report `BuildingReport` ([#356])
 - Add ratio_filter to `building_count` layer ([#356])
+- Configure OQT using files or environment variables ([#255])
 
 ### Other Changes
 
@@ -28,6 +33,7 @@
 - Reports `JrcRequirements`, `SketchmapFitness`, and `MapActionPoc` are not accessibly via the website anymore. If you want to access those reports please use the API.
 - To continue to retrieve the properties of the GeoJSON API response as flat list, you need to set the API request parameter `flatten` to `True` ([#375])
 - To continue to retrieve additional data of an Indicator or Report provided in an API response, you need to set the API request parameter `include_data` to `True` ([#370])
+- Rename environment variable `OHSOME_API`  `OQT_OHSOME_API` ([#255])
 - Make sure to rename the API query parameter `layerName` to `layerKey` and API endpoint `listLayerNames` to `listLayerKeys` ([#376])
 - To continue to retrieve the properties of the GeoJSON API response as flat list, you need to set the API request parameter `flattem` to `True` ([#375])
 - Rename endpoints ([#397]):
@@ -40,6 +46,7 @@
 | `reportNames`                | `reports`                      |
 | `fidFields`                  | `fid-fields`                   |
 
+[#255]: https://github.com/GIScience/ohsome-quality-analyst/pull/255
 [#342]: https://github.com/GIScience/ohsome-quality-analyst/pull/342
 [#356]: https://github.com/GIScience/ohsome-quality-analyst/pull/356
 [#357]: https://github.com/GIScience/ohsome-quality-analyst/pull/357
@@ -77,6 +84,7 @@
 - Add `flatten` parameter to API request. Make flatten of GeoJSON properties of Indicators and Reports optional ([#303])
 - Make calculation of an Indicator for a FeatureCollection or for a Report asynchronous ([#307])
 - Add new Indicator which predicts the building area of the AOI using a trained Random Forest Regressor ([#265])
+- Add support for `groupBy/boundary` queries to the ohsome API client ([#272])
 
 ### Other Changes
 

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -8,7 +8,7 @@ services:
     environment:
       OQT_DATA_DIR: /data
       OQT_LOG_LEVEL: INFO
-      OHSOME_API: https://api.ohsome.org/v1/
+      OQT_OHSOME_API: https://api.ohsome.org/v1/
       POSTGRES_DB: oqt
       POSTGRES_USER: oqt
       POSTGRES_PASSWORD: oqt

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -10,7 +10,7 @@ services:
       context: workers/
       dockerfile: Dockerfile
     environment:
-      OHSOME_API: '${OHSOME_API}'
+      OQT_OHSOME_API: '${OHSOME_API}'
       POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
       POSTGRES_USER: '${POSTGRES_USER}'
       POSTGRES_DB: '${POSTGRES_DB}'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,48 @@
+# Configuration
+
+OQT can be configured using a configuration file or environment variables. Configuration
+values from environment variables have precedence over values from the configuration
+file.
+
+Below is a table listing all possible configuration variables.
+
+| Configuration Variable Name | Environment Variable Name     | Configuration File Name   | Default Value                                       | Description                                                                  |
+| --------------------------- | -------------------------     | -----------------------   | --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Postgres Host               | `POSTGRES_HOST`               | `postgres_host`           | `localhost`                                         | Database connection parameter                                                |
+| Postgres Port               | `POSTGRES_PORT`               | `postgres_port`           | `5445`                                              | "                                                                            |
+| Postgres Database           | `POSTGRES_DB`                 | `postgres_db`             | `oqt`                                               | "                                                                            |
+| Postgres User               | `POSTGRES_USER`               | `postgres_user`           | `oqt`                                               | "                                                                            |
+| Postgres Password           | `POSTGRES_PASSWORD`           | `postgres_password`       | `oqt`                                               | "                                                                            |
+| Configuration File Path     | `OQT_CONFIG`                  | -                         | `workers/ohsome_quality_analyst/config/config.yaml` | Absolute path to the configuration file                                      |
+| Data Directory              | `OQT_DATA_DIR`                | `data_dir`                | `data/`                                             | Absolute path to the directory for raster files                              |
+| Datasets and Features IDs   | -                             | `datasets`                | `[{"regions": {"default": "ogc_fid"}}]`             | Dataset and Features Ids available in the database (see description below)   |
+| Geometry Size Limit (km²)   | `OQT_GEOM_SIZE_LIMIT`         | `geom_size_limit`         | `100`                                               | Area restriction of the input geometry to the OQT API (sqkm)                 |
+| Python Log Level            | `OQT_LOG_LEVEL`               | `log_level`               | `INFO`                                              | Python logging level                                                         |
+| Concurrent Computations     | `OQT_CONCURRENT_COMPUTATIONS` | `concurrent_computations` | `4`                                                 | Limit number of concurrent Indicator computations for one API request        |
+| User Agent                  | `OQT_USER_AGENT`              | `user_agent`              | `ohsome-quality-analyst/{version}`                  | User-Agent header for requests tot the ohsome API                            |
+| ohsome API URL              | `OQT_OHSOME_API`              | `ohsome_api`              | `https://api.ohsome.org/v1/`                        | ohsome API URL                                                               |
+
+_Note on the 'Datasets and Features IDs' configuration:_ Defines the datasets and
+features IDs which are available in the database and for which Indicators should be
+calculated. The `dataset` field refers to the name of the relation and `default` and
+`other` refer to possible identifier of the features. The default configuration looks
+like this:
+
+```yaml
+datasets:
+    regions:
+        default: ogc_fid
+        other: [name] # Optional
+```
+
+## Configuration File
+
+The default path of the configuration file is `workers/config/config.yaml`.
+A sample configuration file can be found in the same directory: `workers/config/sample.config.yaml`.
+All configuration files in this directory (`config`) will be ignored by Git. To change the default configuration file path for OQT set the environment variable `OQT_CONFIG` to the desired path.
+
+To create a new configuration file simply copy the sample configuration file and change the values.
+
+```
+cp sample.config.yaml config.yaml
+```

--- a/docs/development_setup.md
+++ b/docs/development_setup.md
@@ -79,40 +79,9 @@ pre-commit install  # Install pre-commit hooks.
 
 ### Configuration
 
-
-#### Local database
+For all possible configuration parameter please refer to the [configuration documentation](/docs/configuration.md).
 
 For local development no additional configuration is required. Per default OQT will connect to the database defined in `docker-compose.development.yml`.
-
-
-#### Remote database
-
-If access to a remote database is required following environment variables need to be set:
-
-```bash
-POSTGRES_DB
-POSTGRES_USER
-POSTGRES_PASSWORD
-POSTGRES_HOST
-POSTGRES_PORT
-POSTGRES_SCHEMA
-```
-
-> Tip: Above lines can be written to a file (e.g. `.env`), prefixed with `export` and sourced (`source .env`) to make them available to current environment.
->
-> Note: Windows user can set those environment variables with following command `setx POSTGRES_DB`
-
-
-#### ohsome API
-
-The URL to a specific ohsome API can be set with the environment variable `OHSOME_API`. It defaults to [https://api.ohsome.org/v1/](https://api.ohsome.org/v1/)
-
-
-#### Additional options
-
-Additional environment variables are:
-- `OQT_LOG_LEVEL`: Control the logging level of OQT (See logging section)
-- `OQT_GEOM_SIZE_LIMIT`: Control the size limit of the input geometry passed to the API.
 
 
 ### Usage
@@ -178,3 +147,75 @@ curl \
     -d '{"dataset": "regions", "featureId": 1}' \
     | python -m json.tool > response.json
 ```
+
+
+### Tests
+
+All relevant components should be tested. Please write tests for newly integrated functionality. 
+
+Tests are written using the [unittest library](https://docs.python.org/3/library/unittest.html).
+The test runner is [pytest](https://docs.pytest.org/en/stable/).
+Tests are separated into integration tests and unit tests.
+Unit tests should run without having access to the database or services on the internet (e.g. ohsome API).
+
+Run all tests:
+
+```bash
+cd workers/
+pytest tests
+```
+
+
+#### Writing tests
+
+
+##### VCR (videocassette recorder) for tests
+
+All tests that are calling function, which are dependent on external resources (e.g. ohsome API) have to use the [VCR.py](https://vcrpy.readthedocs.io) module: "VCR.py records all HTTP interactions that take place […]."
+This ensures that the positive test result is not dependent on the external resource. The cassettes are stored in the test directory within [fixtures/vcr_cassettes](/workers/tests/integrationtests/fixtures/vcr_cassettes). These cassettes are supposed to be integrated (committed and pushed) to the repository.
+
+The VCR [record mode](https://vcrpy.readthedocs.io/en/latest/usage.html#record-modes) is configurable through the environment variable `VCR_RECORD_MODE`. To ensure that every request is covered by cassettes, run the tests with the record mode `none`. If necessary, the cassettes can be re-recorded by deleting the cassettes and run all tests again, or using the record mode `all`. This is not necessary in normal cases, because not-yet-stored requests are downloaded automatically.
+
+Writing tests using VCR.py with our custom decorator is as easy as: 
+
+```python
+from .utils import oqt_vcr
+
+class TestSomething(unittest.TestCase):
+
+    @oqt_vcr.use_cassette()
+    def test_something(self):
+        oqt.do_something(…)
+        self.assertSomething(something)
+```
+
+Good examples can be found in [test_oqt.py](/workers/tests/integrationtests/test_oqt.py).
+
+
+##### Asynchronous functions
+
+When writing tests for functions which are asynchronous (using the `async/await` pattern) such as the `preprocess` functions of indicator classes, those functions should be called as follows: `asyncio.run(indicator.preprocess())`.
+
+
+### Logging
+
+Logging is enabled by default.
+
+`ohsome_quality_analyst` uses the [logging module](https://docs.python.org/3/library/logging.html).
+
+#### Configuration
+
+The logging module is configured in `config.py`. Both entry-points to
+`ohsome_quality_analyst`, the `cli.py` and the `api.py`, will call the configuration
+function defined in `definitions.py`. The default log level is `INFO`. This can be
+overwritten by setting the environment variable `OQT_LOG_LEVEL` (See also the
+[configuration documentation](docs/configuration.md)).
+
+#### Usage
+
+```python
+import logging
+
+logging.info("Logging message")
+```
+>>>>>>> 8008b974 (Configure OQT using files or environment variables)

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -24,5 +24,9 @@ RUN pip install --no-cache-dir poetry
 RUN python -m poetry install --no-ansi --no-interaction --no-root
 
 # copy all the other files and install the project
-COPY --chown=oqt:oqt . .
+COPY --chown=oqt:oqt ohsome_quality_analyst ohsome_quality_analyst
+COPY --chown=oqt:oqt tests tests
+COPY --chown=oqt:oqt scripts/start_api.py scripts/start_api.py
+COPY --chown=oqt:oqt config/logging.yaml config/logging.yaml
 RUN python -m poetry install --no-ansi --no-interaction
+

--- a/workers/Dockerfile
+++ b/workers/Dockerfile
@@ -28,5 +28,6 @@ COPY --chown=oqt:oqt ohsome_quality_analyst ohsome_quality_analyst
 COPY --chown=oqt:oqt tests tests
 COPY --chown=oqt:oqt scripts/start_api.py scripts/start_api.py
 COPY --chown=oqt:oqt config/logging.yaml config/logging.yaml
+COPY --chown=oqt:oqt setup.cfg setup.cfg
 RUN python -m poetry install --no-ansi --no-interaction
 

--- a/workers/config/logging.yaml
+++ b/workers/config/logging.yaml
@@ -1,8 +1,9 @@
+---
 version: 1
 disable_existing_loggers: False
 formatters:
   default:
-    format: '%(asctime)s - %(levelname)s - %(filename)s - %(funcName)s - %(message)s'
+    format: "%(asctime)s - %(levelname)s - %(filename)s - %(funcName)s - %(message)s"
 handlers:
   default:
     formatter: default

--- a/workers/config/sample.config.yaml
+++ b/workers/config/sample.config.yaml
@@ -1,0 +1,26 @@
+---
+# Database connection parameters;
+postgres_host: localhost
+postgres_port: 5445
+postgres_db: oqt
+postgres_user: oqt
+postgres_password: oqt
+# Data directory for raster files
+# Default: repo-root/data
+data_dir: /some/absolute/path
+# Restrict size of input geometry to the OQT API (sqkm)
+geom_size_limit: 100
+# Python logging level
+log_level: INFO
+# ohsome API URL
+ohsome_api: https://api.ohsome.org/v1/
+# Limit number of concurrent Indicator computations
+concurrent_computations: 4
+# User-Agent header for request to the ohsome API
+# Default: 'ohsome-quality-analyst/{version}'
+user_agent: ohsome-quality-analyst
+# Datasets and Feature IDs available in the database
+datasets:
+  regions:  # Name of relation with GEOM
+    default: ogc_fid  # Default unique id field
+    other: [name] # More unique id fields (optional)

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -29,18 +29,18 @@ from ohsome_quality_analyst.api.request_models import (
     ReportBpolys,
     ReportDatabase,
 )
-from ohsome_quality_analyst.geodatabase import client as db_client
-from ohsome_quality_analyst.utils.definitions import (
+from ohsome_quality_analyst.config import configure_logging
+from ohsome_quality_analyst.definitions import (
     ATTRIBUTION_URL,
     INDICATOR_LAYER,
-    configure_logging,
     get_attribution,
-    get_dataset_names_api,
-    get_fid_fields_api,
+    get_dataset_names,
+    get_fid_fields,
     get_indicator_names,
     get_layer_keys,
     get_report_names,
 )
+from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.utils.exceptions import (
     HexCellsNotFoundError,
     LayerDataSchemaError,
@@ -300,7 +300,7 @@ async def indicator_names():
 async def dataset_names():
     """Get names of available datasets."""
     response = empty_api_response()
-    response["result"] = get_dataset_names_api()
+    response["result"] = get_dataset_names()
     return response
 
 
@@ -324,7 +324,7 @@ async def report_names():
 async def list_fid_fields():
     """List available fid fields for each dataset."""
     response = empty_api_response()
-    response["result"] = get_fid_fields_api()
+    response["result"] = get_fid_fields()
     return response
 
 

--- a/workers/ohsome_quality_analyst/api/request_models.py
+++ b/workers/ohsome_quality_analyst/api/request_models.py
@@ -15,10 +15,10 @@ from geojson import Feature, FeatureCollection
 from pydantic import BaseModel
 
 from ohsome_quality_analyst.base.layer import LayerData
-from ohsome_quality_analyst.utils.definitions import (
+from ohsome_quality_analyst.definitions import (
     INDICATOR_LAYER,
-    get_dataset_names_api,
-    get_fid_fields_api,
+    get_dataset_names,
+    get_fid_fields,
     get_indicator_names,
     get_layer_keys,
     get_report_names,
@@ -28,8 +28,8 @@ from ohsome_quality_analyst.utils.helper import loads_geojson, snake_to_lower_ca
 IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_names()})
 ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})
 LayerEnum = Enum("LayerEnum", {name: name for name in get_layer_keys()})
-DatasetEnum = Enum("DatasetNames", {name: name for name in get_dataset_names_api()})
-FidFieldEnum = Enum("FidFieldEnum", {name: name for name in get_fid_fields_api()})
+DatasetEnum = Enum("DatasetNames", {name: name for name in get_dataset_names()})
+FidFieldEnum = Enum("FidFieldEnum", {name: name for name in get_fid_fields()})
 
 
 class BaseIndicator(BaseModel):

--- a/workers/ohsome_quality_analyst/base/indicator.py
+++ b/workers/ohsome_quality_analyst/base/indicator.py
@@ -15,11 +15,11 @@ from dacite import from_dict
 from geojson import Feature
 
 from ohsome_quality_analyst.base.layer import BaseLayer as Layer
+from ohsome_quality_analyst.definitions import get_attribution, get_metadata
 from ohsome_quality_analyst.html_templates.template import (
     get_template,
     get_traffic_light,
 )
-from ohsome_quality_analyst.utils.definitions import get_attribution, get_metadata
 from ohsome_quality_analyst.utils.helper import flatten_dict, json_serialize
 
 

--- a/workers/ohsome_quality_analyst/base/report.py
+++ b/workers/ohsome_quality_analyst/base/report.py
@@ -8,11 +8,11 @@ from dacite import from_dict
 from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
+from ohsome_quality_analyst.definitions import get_attribution, get_metadata
 from ohsome_quality_analyst.html_templates.template import (
     get_template,
     get_traffic_light,
 )
-from ohsome_quality_analyst.utils.definitions import get_attribution, get_metadata
 from ohsome_quality_analyst.utils.helper import flatten_dict
 
 

--- a/workers/ohsome_quality_analyst/cli/cli.py
+++ b/workers/ohsome_quality_analyst/cli/cli.py
@@ -14,14 +14,13 @@ from ohsome_quality_analyst.api.request_models import (
     ReportDatabase,
 )
 from ohsome_quality_analyst.cli import options
-from ohsome_quality_analyst.geodatabase import client as db_client
-from ohsome_quality_analyst.utils.definitions import (
-    DATASETS,
+from ohsome_quality_analyst.config import configure_logging, get_config_value
+from ohsome_quality_analyst.definitions import (
     INDICATOR_LAYER,
-    configure_logging,
     load_layer_definitions,
     load_metadata,
 )
+from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.utils.helper import json_serialize, write_geojson
 
 
@@ -71,13 +70,13 @@ def list_layers():
 @cli.command("list-datasets")
 def list_datasets():
     """List available datasets."""
-    click.echo(tuple(DATASETS.keys()))
+    click.echo(tuple(get_config_value("datasets").keys()))
 
 
 @cli.command("list-fid-fields")
 def list_fid_fields():
     """List available fid fields for each dataset."""
-    for name, dataset in DATASETS.items():
+    for name, dataset in get_config_value("datasets").items():
         click.echo(name + ": ")
         click.echo("  - default: " + dataset["default"])
         click.echo("  - other: " + ", ".join(dataset.get("other", [])))
@@ -204,7 +203,7 @@ def create_report(
     "-d",
     required=True,
     type=click.Choice(
-        DATASETS.keys(),
+        get_config_value("datasets").keys(),
         case_sensitive=True,
     ),
     help=("Choose a dataset containing geometries."),

--- a/workers/ohsome_quality_analyst/cli/options.py
+++ b/workers/ohsome_quality_analyst/cli/options.py
@@ -4,11 +4,8 @@ Define Click command options to avoid redundancy.
 
 import click
 
-from ohsome_quality_analyst.utils.definitions import (
-    DATASETS,
-    load_layer_definitions,
-    load_metadata,
-)
+from ohsome_quality_analyst.config import get_config_value
+from ohsome_quality_analyst.definitions import load_layer_definitions, load_metadata
 
 indicator_name = click.option(
     "--indicator-name",
@@ -55,7 +52,7 @@ dataset_name = click.option(
     "--dataset-name",
     "-d",
     type=click.Choice(
-        DATASETS.keys(),
+        get_config_value("datasets").keys(),
         case_sensitive=True,
     ),
     help=("Choose a dataset containing geometries."),

--- a/workers/ohsome_quality_analyst/config.py
+++ b/workers/ohsome_quality_analyst/config.py
@@ -1,0 +1,157 @@
+"""Load configuration from environment variables or configuration file on disk."""
+
+import logging
+import logging.config
+import os
+import sys
+from types import MappingProxyType
+from typing import Union
+
+import rpy2.rinterface_lib.callbacks
+import yaml
+
+from ohsome_quality_analyst import __version__ as oqt_version
+
+
+def get_config_path() -> str:
+    """Get configuration file path
+
+    Read value of the environment variable 'OQT_CONFIG' or use default 'config.yaml'
+    """
+    return os.getenv(
+        "OQT_CONFIG",
+        default=os.path.abspath(
+            os.path.join(
+                os.path.dirname(
+                    os.path.abspath(__file__),
+                ),
+                "..",
+                "config",
+                "config.yaml",
+            ),
+        ),
+    )
+
+
+def load_config_default() -> dict:
+    return {
+        "postgres_host": "localhost",
+        "postgres_port": 5445,
+        "postgres_db": "oqt",
+        "postgres_user": "oqt",
+        "postgres_password": "oqt",
+        "data_dir": get_default_data_dir(),
+        "geom_size_limit": 100,
+        "log_level": "INFO",
+        "ohsome_api": "https://api.ohsome.org/v1/",
+        "concurrent_computations": 4,
+        "user_agent": "ohsome-quality-analyst/{}".format(oqt_version),
+        "datasets": {
+            "regions": {
+                "default": "ogc_fid",
+                "other": ["name"],
+            }
+        },
+    }
+
+
+def load_config_from_file(path: str) -> dict:
+    """Load configuration from file on disk."""
+    # TODO: Raise error if OQT_CONFIG has been set
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            return yaml.safe_load(f)
+    else:
+        return {}
+
+
+def load_config_from_env() -> dict:
+    """Load configuration from environment variables."""
+    cfg = {
+        "postgres_host": os.getenv("POSTGRES_HOST"),
+        "postgres_port": os.getenv("POSTGRES_PORT"),
+        "postgres_db": os.getenv("POSTGRES_DB"),
+        "postgres_user": os.getenv("POSTGRES_USER"),
+        "postgres_password": os.getenv("POSTGRES_PASSWORD"),
+        "data_dir": os.getenv("OQT_DATA_DIR"),
+        "geom_size_limit": os.getenv("OQT_GEOM_SIZE_LIMIT"),
+        "ohsome_api": os.getenv("OQT_OHSOME_API"),
+        "concurrent_computations": os.getenv("OQT_CONCURRENT_COMPUTATIONS"),
+        "user_agent": os.getenv("OQT_USER_AGENT"),
+    }
+    return {k: v for k, v in cfg.items() if v is not None}
+
+
+def get_config() -> MappingProxyType:
+    """Get configuration variables from environment and file.
+
+    Configuration values from file will be given precedence over default vaules.
+    Configuration values from environment variables will be given precedence over file
+    values.
+    """
+    cfg = load_config_default()
+    cfg_file = load_config_from_file(get_config_path())
+    cfg_env = load_config_from_env()
+    cfg.update(cfg_file)
+    cfg.update(cfg_env)
+    return MappingProxyType(cfg)
+
+
+def get_config_value(key: str) -> Union[str, int, dict]:
+    config = get_config()
+    return config[key]
+
+
+def get_default_data_dir() -> str:
+    """Get the default OQT data directory path.
+
+    Default data directory is a directory named 'data' at the root of the repository.
+    """
+    return os.path.join(
+        os.path.dirname(
+            os.path.abspath(__file__),
+        ),
+        "..",
+        "..",
+        "data",
+    )
+
+
+def load_logging_config():
+    """Read logging configuration from configuration file."""
+    path = os.path.join(
+        os.path.dirname(
+            os.path.abspath(__file__),
+        ),
+        "..",
+        "config",
+        "logging.yaml",
+    )
+    level = get_log_level()
+    with open(path, "r") as f:
+        config = yaml.safe_load(f)
+    config["root"]["level"] = getattr(logging, level.upper())
+    return config
+
+
+def get_log_level():
+    if "pydevd" in sys.modules or "pdb" in sys.modules:
+        default_level = "DEBUG"
+    else:
+        default_level = "INFO"
+    return os.getenv("OQT_LOG_LEVEL", default=default_level)
+
+
+def configure_logging() -> None:
+    """Configure logging level and format."""
+
+    class RPY2LoggingFilter(logging.Filter):  # Sensitive
+        def filter(self, record):
+            return " library ‘/usr/share/R/library’ contains no packages" in record.msg
+
+    # Avoid R library contains no packages WARNING logs.
+    # OQT has no dependencies on additional R libraries.
+    rpy2.rinterface_lib.callbacks.logger.addFilter(RPY2LoggingFilter())
+    # Avoid a huge amount of DEBUG logs from matplotlib font_manager.py
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.INFO)
+    logging.config.dictConfig(load_logging_config())

--- a/workers/ohsome_quality_analyst/config.py
+++ b/workers/ohsome_quality_analyst/config.py
@@ -57,7 +57,6 @@ def load_config_default() -> dict:
 
 def load_config_from_file(path: str) -> dict:
     """Load configuration from file on disk."""
-    # TODO: Raise error if OQT_CONFIG has been set
     if os.path.isfile(path):
         with open(path, "r") as f:
             return yaml.safe_load(f)

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -1,38 +1,17 @@
 """Global Variables and Functions."""
-import errno
 import glob
 import logging
-import logging.config
 import os
-import sys
 from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Dict, List, Optional
 
-import rpy2.rinterface_lib.callbacks
 import yaml
 
-from ohsome_quality_analyst import __version__ as oqt_version
 from ohsome_quality_analyst.base.layer import LayerDefinition
+from ohsome_quality_analyst.config import get_config_value
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 from ohsome_quality_analyst.utils.helper import flatten_sequence, get_module_dir
-
-# Dataset names and fid fields which are available in the Geodatabase
-DATASETS = MappingProxyType(  # Immutable dict
-    {
-        "regions": {"default": "ogc_fid", "other": ("name",)},
-        "admin_world_water": {
-            "default": "id",
-            "other": (
-                "country",  # ISO 3166-1 alpha-3
-                "enname",  # English name
-            ),
-        },
-    }
-)
-# Dataset names and fid fields which are through the API
-DATASETS_API = DATASETS.copy()
-DATASETS_API.pop("admin_world_water")
 
 
 @dataclass(frozen=True)
@@ -77,7 +56,6 @@ RASTER_DATASETS = (
         -999,
     ),
 )
-
 
 # Possible indicator layer combinations
 INDICATOR_LAYER = (
@@ -132,15 +110,6 @@ INDICATOR_LAYER = (
     ("TagsRatio", "jrc_mass_gathering_sites_count"),
     ("Minimal", "minimal"),
 )
-OHSOME_API = os.getenv("OHSOME_API", default="https://api.ohsome.org/v1/").rstrip("/")
-# Input geometry size limit in sqkm for API requests
-# TODO: decide on default value
-GEOM_SIZE_LIMIT = os.getenv("OQT_GEOM_SIZE_LIMIT", default=100)
-
-USER_AGENT = os.getenv(
-    "OQT_USER_AGENT",
-    default="ohsome-quality-analyst/{0}".format(oqt_version),
-)
 
 ATTRIBUTION_TEXTS = MappingProxyType(
     {
@@ -154,41 +123,6 @@ ATTRIBUTION_URL = (
     "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/"
     + "COPYRIGHTS.md"
 )
-
-
-def get_log_level():
-    if "pydevd" in sys.modules or "pdb" in sys.modules:
-        default_level = "DEBUG"
-    else:
-        default_level = "INFO"
-    return os.getenv("OQT_LOG_LEVEL", default=default_level)
-
-
-def load_logging_config():
-    """Read logging config from configuration file."""
-    level = get_log_level()
-    logging_path = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "logging.yaml"
-    )
-    with open(logging_path, "r") as f:
-        logging_config = yaml.safe_load(f)
-    logging_config["root"]["level"] = getattr(logging, level.upper())
-    return logging_config
-
-
-def configure_logging() -> None:
-    """Configure logging level and format."""
-
-    class RPY2LoggingFilter(logging.Filter):  # Sensitive
-        def filter(self, record):
-            return " library ‘/usr/share/R/library’ contains no packages" in record.msg
-
-    # Avoid R library contains no packages WARNING logs.
-    # OQT has no dependencies on additional R libraries.
-    rpy2.rinterface_lib.callbacks.logger.addFilter(RPY2LoggingFilter())
-    # Avoid a huge amount of DEBUG logs from matplotlib font_manager.py
-    logging.getLogger("matplotlib.font_manager").setLevel(logging.INFO)
-    logging.config.dictConfig(load_logging_config())
 
 
 def load_metadata(module_name: str) -> Dict:
@@ -302,7 +236,7 @@ def get_layer_keys() -> List[str]:
 
 
 def get_dataset_names() -> List[str]:
-    return list(DATASETS.keys())
+    return list(get_config_value("datasets").keys())
 
 
 def get_raster_dataset_names() -> List[str]:
@@ -328,36 +262,7 @@ def get_raster_dataset(name: str) -> RasterDataset:
 
 
 def get_fid_fields() -> List[str]:
-    return flatten_sequence(DATASETS)
-
-
-def get_dataset_names_api() -> List[str]:
-    return list(DATASETS_API.keys())
-
-
-def get_fid_fields_api() -> List[str]:
-    return flatten_sequence(DATASETS_API)
-
-
-def get_data_dir() -> str:
-    """Get the OQT data directory path."""
-    default_dir = os.path.join(
-        os.path.dirname(
-            os.path.abspath(__file__),
-        ),
-        "..",
-        "..",
-        "..",
-        "data",
-    )
-    data_dir = os.getenv("OQT_DATA_DIR", default=default_dir)
-    if not os.path.exists(data_dir):
-        raise FileNotFoundError(
-            errno.ENOENT,
-            "OQT data directory does not exists.",
-            data_dir,
-        )
-    return data_dir
+    return flatten_sequence(get_config_value("datasets").values())
 
 
 def get_attribution(data_keys: list) -> str:

--- a/workers/ohsome_quality_analyst/indicators/building_completeness/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/building_completeness/indicator.py
@@ -14,9 +14,9 @@ from geojson import Feature, FeatureCollection
 import ohsome_quality_analyst.geodatabase.client as db_client
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.base.layer import BaseLayer as Layer
+from ohsome_quality_analyst.definitions import get_raster_dataset
 from ohsome_quality_analyst.ohsome import client as ohsome_client
 from ohsome_quality_analyst.raster import client as raster_client
-from ohsome_quality_analyst.utils.definitions import get_raster_dataset
 from ohsome_quality_analyst.utils.exceptions import HexCellsNotFoundError
 
 

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
@@ -9,10 +9,10 @@ from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.base.layer import BaseLayer as Layer
+from ohsome_quality_analyst.definitions import get_attribution, get_raster_dataset
 from ohsome_quality_analyst.geodatabase.client import get_area_of_bpolys
 from ohsome_quality_analyst.ohsome import client as ohsome_client
 from ohsome_quality_analyst.raster.client import get_zonal_stats
-from ohsome_quality_analyst.utils.definitions import get_attribution, get_raster_dataset
 
 
 class GhsPopComparisonBuildings(BaseIndicator):

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
@@ -9,10 +9,10 @@ from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.base.layer import BaseLayer as Layer
+from ohsome_quality_analyst.definitions import get_attribution, get_raster_dataset
 from ohsome_quality_analyst.geodatabase.client import get_area_of_bpolys
 from ohsome_quality_analyst.ohsome import client as ohsome_client
 from ohsome_quality_analyst.raster.client import get_zonal_stats
-from ohsome_quality_analyst.utils.definitions import get_attribution, get_raster_dataset
 
 
 class GhsPopComparisonRoads(BaseIndicator):

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -355,14 +355,6 @@ async def create_all_indicators(
     Possible Indicator/Layer combinations are defined in `definitions.py`.
     This functions executes `create_indicator()` function up to four times concurrently.
     """
-
-    async def sem_task(
-        task, semaphore=asyncio.Semaphore(get_config_value("concurrent_computations"))
-    ):
-        """Run task with semaphore. Semaphore limits num of concurrent executions."""
-        async with semaphore:
-            return await task
-
     if indicator_name is not None and layer_key is None:
         layers = get_valid_layers(indicator_name)
         indicator_layer = [(indicator_name, lay) for lay in layers]

--- a/workers/ohsome_quality_analyst/raster/client.py
+++ b/workers/ohsome_quality_analyst/raster/client.py
@@ -7,7 +7,8 @@ import geojson
 from pyproj import Transformer
 from rasterstats import zonal_stats
 
-from ohsome_quality_analyst.utils.definitions import RasterDataset, get_data_dir
+from ohsome_quality_analyst.config import get_config_value
+from ohsome_quality_analyst.definitions import RasterDataset
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetNotFoundError
 
 
@@ -50,7 +51,7 @@ def transform(feature: geojson.Feature, raster: RasterDataset):
 
 def get_raster_path(raster: RasterDataset) -> str:
     """Get the path of the raster file on disk."""
-    path = os.path.join(get_data_dir(), raster.filename)
+    path = os.path.join(get_config_value("data_dir"), raster.filename)
     if not os.path.exists(path):
         raise RasterDatasetNotFoundError(raster)
     return path

--- a/workers/ohsome_quality_analyst/reports/minimal/report.py
+++ b/workers/ohsome_quality_analyst/reports/minimal/report.py
@@ -1,5 +1,5 @@
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
-from ohsome_quality_analyst.utils.definitions import get_attribution
+from ohsome_quality_analyst.definitions import get_attribution
 
 
 class Minimal(BaseReport):

--- a/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/report.py
+++ b/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/report.py
@@ -1,5 +1,5 @@
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
-from ohsome_quality_analyst.utils.definitions import get_attribution
+from ohsome_quality_analyst.definitions import get_attribution
 
 
 class MultilevelMappingSaturation(BaseReport):

--- a/workers/ohsome_quality_analyst/reports/road_report/report.py
+++ b/workers/ohsome_quality_analyst/reports/road_report/report.py
@@ -1,5 +1,5 @@
 from ohsome_quality_analyst.base.report import BaseReport, IndicatorLayer
-from ohsome_quality_analyst.utils.definitions import get_attribution
+from ohsome_quality_analyst.definitions import get_attribution
 
 
 class RoadReport(BaseReport):

--- a/workers/scripts/run_mapping_saturation_models.py
+++ b/workers/scripts/run_mapping_saturation_models.py
@@ -11,8 +11,8 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 import ohsome_quality_analyst.geodatabase.client as db_client
 import ohsome_quality_analyst.ohsome.client as ohsome_client
+from ohsome_quality_analyst.definitions import get_layer_definition
 from ohsome_quality_analyst.indicators.mapping_saturation import models
-from ohsome_quality_analyst.utils.definitions import get_layer_definition
 
 
 def plot(xdata, ydata, model_list):

--- a/workers/scripts/start_api.py
+++ b/workers/scripts/start_api.py
@@ -3,7 +3,7 @@
 import click
 import uvicorn
 
-from ohsome_quality_analyst.utils.definitions import load_logging_config
+from ohsome_quality_analyst.config import load_logging_config
 
 
 @click.command()

--- a/workers/tests/integrationtests/__init__.py
+++ b/workers/tests/integrationtests/__init__.py
@@ -1,3 +1,3 @@
-from ohsome_quality_analyst.utils.definitions import configure_logging
+from ohsome_quality_analyst.config import configure_logging
 
 configure_logging()

--- a/workers/tests/integrationtests/test_indicator_building_completeness.py
+++ b/workers/tests/integrationtests/test_indicator_building_completeness.py
@@ -26,7 +26,7 @@ class TestIndicatorBuildingCompleteness(unittest.TestCase):
         self.layer = get_layer_fixture("building_area")
         self.indicator = BuildingCompleteness(feature=self.feature, layer=self.layer)
 
-    @mock.patch("ohsome_quality_analyst.raster.client.get_data_dir")
+    @mock.patch("ohsome_quality_analyst.raster.client.get_config_value")
     @oqt_vcr.use_cassette()
     def test_indicator(self, mock_get_data_dir):
         mock_get_data_dir.return_value = os.path.join(
@@ -70,7 +70,7 @@ class TestIndicatorBuildingCompleteness(unittest.TestCase):
         self.indicator.create_figure()
         self.assertIsNotNone(self.indicator.result.svg)
 
-    @mock.patch("ohsome_quality_analyst.raster.client.get_data_dir")
+    @mock.patch("ohsome_quality_analyst.raster.client.get_config_value")
     def test_get_smod_class_share(self, mock_get_data_dir):
         mock_get_data_dir.return_value = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "fixtures", "raster"

--- a/workers/tests/integrationtests/test_raster.py
+++ b/workers/tests/integrationtests/test_raster.py
@@ -4,7 +4,7 @@ import unittest
 import geojson
 
 import ohsome_quality_analyst.raster.client as raster_client
-from ohsome_quality_analyst.utils.definitions import get_raster_dataset
+from ohsome_quality_analyst.definitions import get_raster_dataset
 
 
 class TestRaster(unittest.TestCase):

--- a/workers/tests/integrationtests/utils.py
+++ b/workers/tests/integrationtests/utils.py
@@ -6,7 +6,7 @@ import geojson
 import vcr
 
 from ohsome_quality_analyst.base.layer import LayerDefinition
-from ohsome_quality_analyst.utils.definitions import get_layer_definition
+from ohsome_quality_analyst.definitions import get_layer_definition
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURE_DIR = os.path.join(TEST_DIR, "fixtures", "vcr_cassettes")

--- a/workers/tests/unittests/__init__.py
+++ b/workers/tests/unittests/__init__.py
@@ -1,3 +1,3 @@
-from ohsome_quality_analyst.utils.definitions import configure_logging
+from ohsome_quality_analyst.config import configure_logging
 
 configure_logging()

--- a/workers/tests/unittests/fixtures/config.yaml
+++ b/workers/tests/unittests/fixtures/config.yaml
@@ -1,0 +1,26 @@
+---
+# Database connection parameters;
+postgres_host: localhost
+postgres_port: 5445
+postgres_db: oqt
+postgres_user: oqt
+postgres_password: oqt
+# Data directory for raster files
+# Default: repo-root/data
+data_dir: /some/absolute/path
+# Restrict size of input geometry to the OQT API (sqkm)
+geom_size_limit: 100
+# Python logging level
+log_level: INFO
+# ohsome API URL
+ohsome_api: https://api.ohsome.org/v1/
+# Limit number of concurrent Indicator computations
+concurrent_computations: 4
+# User-Agent header for request to the ohsome API
+# Default: 'ohsome-quality-analyst/{version}'
+user_agent: ohsome-quality-analyst
+# Datasets and Feature IDs available in the database
+datasets:
+  regions:  # Name of relation with GEOM
+    default: ogc_fid  # Default unique id field
+    other: [name] # More unique id fields (optional)

--- a/workers/tests/unittests/mapping_saturation/__init__.py
+++ b/workers/tests/unittests/mapping_saturation/__init__.py
@@ -1,3 +1,0 @@
-from ohsome_quality_analyst.utils.definitions import configure_logging
-
-configure_logging()

--- a/workers/tests/unittests/test_cli.py
+++ b/workers/tests/unittests/test_cli.py
@@ -57,6 +57,10 @@ class TestCliUnit(unittest.TestCase):
         assert result.exit_code == 2
 
     @mock.patch("ohsome_quality_analyst.oqt.create_indicator", mock.AsyncMock())
+    # Do not depend on database
+    @mock.patch(
+        "ohsome_quality_analyst.geodatabase.client.get_feature_ids", mock.AsyncMock()
+    )
     def test_create_all_indicators_valid_opts(self):
         result = self.runner.invoke(
             cli,

--- a/workers/tests/unittests/test_config.py
+++ b/workers/tests/unittests/test_config.py
@@ -93,8 +93,8 @@ class TestConfig(unittest.TestCase):
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_get_config_value(self):
-        for _ in self.keys:
-            val = config.get_config_value("geom_size_limit")
+        for key in self.keys:
+            val = config.get_config_value(key)
             assert isinstance(val, int) or isinstance(val, str) or isinstance(val, dict)
 
     @mock.patch.dict(

--- a/workers/tests/unittests/test_config.py
+++ b/workers/tests/unittests/test_config.py
@@ -93,7 +93,7 @@ class TestConfig(unittest.TestCase):
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_get_config_value(self):
-        for key in self.keys:
+        for _ in self.keys:
             val = config.get_config_value("geom_size_limit")
             assert isinstance(val, int) or isinstance(val, str) or isinstance(val, dict)
 

--- a/workers/tests/unittests/test_config.py
+++ b/workers/tests/unittests/test_config.py
@@ -1,0 +1,122 @@
+import os
+import unittest
+from types import MappingProxyType
+from unittest import mock
+
+from ohsome_quality_analyst import config
+
+
+class TestConfig(unittest.TestCase):
+    def setUp(self):
+        self.keys = {
+            "postgres_host",
+            "postgres_port",
+            "postgres_db",
+            "postgres_user",
+            "postgres_password",
+            "data_dir",
+            "geom_size_limit",
+            "log_level",
+            "ohsome_api",
+            "concurrent_computations",
+            "user_agent",
+            "datasets",
+        }
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_get_config_path_empty_env(self):
+        self.assertEqual(
+            config.get_config_path(),
+            os.path.abspath(
+                os.path.join(
+                    os.path.dirname(__file__),
+                    "..",
+                    "..",
+                    "config",
+                    "config.yaml",
+                )
+            ),
+        )
+
+    @mock.patch.dict("os.environ", {"OQT_CONFIG": "/some/absolute/path"}, clear=True)
+    def test_get_config_path_set_env(self):
+        self.assertEqual(config.get_config_path(), "/some/absolute/path")
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_config_default(self):
+        cfg = config.load_config_default()
+        self.assertIsInstance(cfg, dict)
+        self.assertEqual(self.keys, cfg.keys())
+
+    @mock.patch.dict(
+        "os.environ",
+        {
+            "OQT_CONFIG": os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "fixtures",
+                "config.yaml",
+            )
+        },
+        clear=True,
+    )
+    def test_load_config_from_file(self):
+        path = config.get_config_path()
+        cfg = config.load_config_from_file(path)
+        self.assertIsInstance(cfg, dict)
+        self.assertTrue(cfg)  # Check if empty
+        self.assertTrue(set(cfg.keys()).issubset(self.keys))
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_load_config_from_env_empty(self):
+        cfg = config.load_config_from_env()
+        self.assertTrue(set(cfg.keys()).issubset(set(self.keys)))
+        self.assertEqual(cfg, {})
+
+    @mock.patch.dict(
+        "os.environ",
+        {"OQT_GEOM_SIZE_LIMIT": "200", "POSTGRES_HOST": "foo"},
+        clear=True,
+    )
+    def test_load_config_from_env_set(self):
+        cfg = config.load_config_from_env()
+        self.assertTrue(set(cfg.keys()).issubset(set(self.keys)))
+        self.assertDictEqual(
+            cfg,
+            {"geom_size_limit": "200", "postgres_host": "foo"},
+        )
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_get_config(self):
+        cfg = config.get_config()
+        self.assertIsInstance(cfg, MappingProxyType)
+        self.assertEqual(self.keys, cfg.keys())
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_get_config_value(self):
+        for key in self.keys:
+            val = config.get_config_value("geom_size_limit")
+            assert isinstance(val, int) or isinstance(val, str) or isinstance(val, dict)
+
+    @mock.patch.dict(
+        "os.environ",
+        {"OQT_CONFIG": ""},
+        clear=True,
+    )
+    def test_get_config_env_empty_str(self):
+        cfg = config.get_config()
+        self.assertIsInstance(cfg, MappingProxyType)
+        self.assertEqual(self.keys, cfg.keys())
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_get_data_dir_unset_env(self):
+        data_dir = config.get_default_data_dir()
+        expected = os.path.join(
+            os.path.dirname(
+                os.path.abspath(__file__),
+            ),
+            "..",
+            "..",
+            "..",
+            "data",
+        )
+        self.assertTrue(os.path.samefile(data_dir, expected))

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -1,18 +1,11 @@
-import os
-import tempfile
 import unittest
-from unittest import mock
 
+from ohsome_quality_analyst import definitions
 from ohsome_quality_analyst.base.layer import LayerDefinition
-from ohsome_quality_analyst.utils import definitions
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 
 class TestDefinitions(unittest.TestCase):
-    def test_load_logging_config(self):
-        config = definitions.load_logging_config()
-        self.assertIsInstance(config, dict)
-
     def test_load_metadata(self):
         metadata = definitions.load_metadata("indicators")
         self.assertIsInstance(metadata, dict)
@@ -54,18 +47,6 @@ class TestDefinitions(unittest.TestCase):
         fields = definitions.get_fid_fields()
         self.assertIsInstance(fields, list)
 
-    def test_get_dataset_names_api(self):
-        names = definitions.get_dataset_names_api()
-        self.assertIsInstance(names, list)
-        self.assertIn("regions", names)
-        self.assertNotIn("gadm", names)
-
-    def test_get_fid_fields_api(self):
-        fields = definitions.get_fid_fields_api()
-        self.assertIsInstance(fields, list)
-        self.assertIn("name", fields)
-        self.assertIn("ogc_fid", fields)
-
     def test_get_raster_dataset(self):
         raster = definitions.get_raster_dataset("GHS_BUILT_R2018A")
         self.assertIsInstance(raster, definitions.RasterDataset)
@@ -73,41 +54,6 @@ class TestDefinitions(unittest.TestCase):
     def test_get_raster_dataset_undefined(self):
         with self.assertRaises(RasterDatasetUndefinedError):
             definitions.get_raster_dataset("foo")
-
-    @mock.patch.dict("os.environ", {}, clear=True)
-    def test_get_data_dir_unset_env(self):
-        data_dir = definitions.get_data_dir()
-        expected = os.path.join(
-            os.path.dirname(
-                os.path.abspath(__file__),
-            ),
-            "..",
-            "..",
-            "..",
-            "data",
-        )
-        self.assertTrue(os.path.samefile(data_dir, expected))
-
-    def test_get_data_dir_set_env(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            custom_data_dir = os.path.join(tmpdirname, "oqt-custom")
-            os.mkdir(custom_data_dir)
-            with mock.patch.dict(
-                "os.environ",
-                {"OQT_DATA_DIR": custom_data_dir},
-                clear=True,
-            ):
-                data_dir = definitions.get_data_dir()
-            self.assertEqual(data_dir, custom_data_dir)
-
-    @mock.patch.dict(
-        "os.environ",
-        {"OQT_DATA_DIR": os.path.join(tempfile.gettempdir(), "oqt-foo")},
-        clear=True,
-    )
-    def test_get_data_dir_error(self):
-        with self.assertRaises(FileNotFoundError):
-            definitions.get_data_dir()
 
     def test_get_attribution(self):
         attribution = definitions.get_attribution(["OSM"])

--- a/workers/tests/unittests/test_helper.py
+++ b/workers/tests/unittests/test_helper.py
@@ -6,12 +6,12 @@ import unittest
 import numpy as np
 from geojson import Feature, Polygon
 
+from ohsome_quality_analyst.definitions import load_metadata
 from ohsome_quality_analyst.indicators.mapping_saturation import models
 from ohsome_quality_analyst.indicators.minimal.indicator import (
     Minimal as MinimalIndicator,
 )
 from ohsome_quality_analyst.reports.minimal.report import Minimal as MinimalReport
-from ohsome_quality_analyst.utils.definitions import load_metadata
 from ohsome_quality_analyst.utils.helper import (
     flatten_dict,
     flatten_sequence,

--- a/workers/tests/unittests/test_load_layers.py
+++ b/workers/tests/unittests/test_load_layers.py
@@ -3,7 +3,7 @@ import unittest
 from schema import Optional, Or, Schema
 
 from ohsome_quality_analyst.base.layer import LayerDefinition
-from ohsome_quality_analyst.utils.definitions import (
+from ohsome_quality_analyst.definitions import (
     get_layer_definition,
     load_layer_definitions,
 )

--- a/workers/tests/unittests/test_load_metadata.py
+++ b/workers/tests/unittests/test_load_metadata.py
@@ -2,7 +2,7 @@ import unittest
 
 from schema import Schema
 
-from ohsome_quality_analyst.utils.definitions import get_metadata, load_metadata
+from ohsome_quality_analyst.definitions import get_metadata, load_metadata
 
 
 class TestReadMetadata(unittest.TestCase):

--- a/workers/tests/unittests/test_logging.py
+++ b/workers/tests/unittests/test_logging.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 
-from ohsome_quality_analyst.utils.definitions import configure_logging
+from ohsome_quality_analyst.config import configure_logging
 
 
 class TestLogging(unittest.TestCase):

--- a/workers/tests/unittests/utils.py
+++ b/workers/tests/unittests/utils.py
@@ -3,7 +3,7 @@ import os
 import geojson
 
 from ohsome_quality_analyst.base.layer import LayerDefinition
-from ohsome_quality_analyst.utils.definitions import get_layer_definition
+from ohsome_quality_analyst.definitions import get_layer_definition
 
 
 def get_geojson_fixture(name):


### PR DESCRIPTION
### Description
Configure OQT using files or environment variables.

All configuration can be done using environment variables.

All configuration can also be done by providing a configuration file (`yaml` format). 
The default configuration file path is `workers/config/config.yaml`. The path to the configuration can be changed by setting the path in the environment variable `OQT_CONFIG`. 
A sample configuration file is provided at `workers/config/config.yaml`.

### Corresponding issue
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
- [x] Update import statements of definitions.py
- [x] Write configuration docs
    - [x] Provide a table with all possible configuration variables
    - [x] Provide prose on how to setup config files
- [x] Clean up commit history
- [x] Add configuration for semaphore (#307)

Open question:
- Should configuration variables be made available as globals through definitions.py? -> No. Two functions to get either all config vars or a single value for a given key are provided.
- Tests for config are very minmal. Should more time be spent to implement further tests?