### PR TITLE
GHS_POP indicators use raster from disc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Other Changes
 
+- Indicators based on GHS-POP use now raster file stored on disk instead of raster in the database
 - Use ([`rasterstats`]) to provide access to third-party raster datasets stored on disk ([#227])
 - Utilize `singledispatch` for `create_indicator` function of the `oqt` module ([#239])
 - Add `landmarks` layer [#246])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Other Changes
 
-- Indicators based on GHS-POP use now raster file stored on disk instead of raster in the database
 - Use ([`rasterstats`]) to provide access to third-party raster datasets stored on disk ([#227])
 - Utilize `singledispatch` for `create_indicator` function of the `oqt` module ([#239])
 - Add `landmarks` layer [#246])
@@ -17,6 +16,7 @@
 - Support any dataset, not just "regions" for CLI function `create_all_indicators` ([#254])
 - Fix concurrent execution of CLI function `create_all_indicators` using async and semaphores ([#254])
 - Support choosing a single indicator and/or single layer for CLI command `create_all_indicators` ([#254])
+- Indicators based on GHS-POP use now raster file stored on disk instead of raster in the database ([#276])
 
 [#221]: https://github.com/GIScience/ohsome-quality-analyst/pull/221
 [#227]: https://github.com/GIScience/ohsome-quality-analyst/pull/227
@@ -24,6 +24,7 @@
 [#246]: https://github.com/GIScience/ohsome-quality-analyst/pull/246
 [#254]: https://github.com/GIScience/ohsome-quality-analyst/pull/254
 [#266]: https://github.com/GIScience/ohsome-quality-analyst/pull/266
+[#276]: https://github.com/GIScience/ohsome-quality-analyst/pull/276
 [`rasterstats`]: https://github.com/perrygeo/python-rasterstats
 [`openpoiservice`]: https://github.com/GIScience/openpoiservice
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Support any dataset, not just "regions" for CLI function `create_all_indicators` ([#254])
 - Fix concurrent execution of CLI function `create_all_indicators` using async and semaphores ([#254])
 - Support choosing a single indicator and/or single layer for CLI command `create_all_indicators` ([#254])
-- Indicators based on GHS-POP use now raster file stored on disk instead of raster in the database ([#276])
+- Indicators based on GHS-POP use raster file stored on disk instead of raster in the database ([#276])
 
 [#221]: https://github.com/GIScience/ohsome-quality-analyst/pull/221
 [#227]: https://github.com/GIScience/ohsome-quality-analyst/pull/227

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
@@ -1,18 +1,17 @@
 import logging
-import os
 from io import StringIO
 from string import Template
 
 import dateutil.parser
 import matplotlib.pyplot as plt
 import numpy as np
-import rasterstats
 from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.geodatabase.client import get_area_of_bpolys
 from ohsome_quality_analyst.ohsome import client as ohsome_client
-from ohsome_quality_analyst.utils.definitions import get_attribution
+from ohsome_quality_analyst.raster.client import get_zonal_stats
+from ohsome_quality_analyst.utils.definitions import get_attribution, get_raster_dataset
 
 
 class GhsPopComparisonBuildings(BaseIndicator):
@@ -51,18 +50,8 @@ class GhsPopComparisonBuildings(BaseIndicator):
         return 0.75 * np.sqrt(pop_per_sqkm)
 
     async def preprocess(self) -> None:
-        raster = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "data",
-                "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
-            )
-        )
-        stats = rasterstats.zonal_stats(self.feature, raster, stats="sum")
+        raster = get_raster_dataset("GHS_POP_R2019A")
+        stats = get_zonal_stats(self.feature, raster, stats="sum")
         pop_count = stats[0]["sum"]
         area = await get_area_of_bpolys(self.feature.geometry)
 

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_buildings/indicator.py
@@ -51,8 +51,7 @@ class GhsPopComparisonBuildings(BaseIndicator):
 
     async def preprocess(self) -> None:
         raster = get_raster_dataset("GHS_POP_R2019A")
-        stats = get_zonal_stats(self.feature, raster, stats="sum")
-        pop_count = stats[0]["sum"]
+        pop_count = get_zonal_stats(self.feature, raster, stats="sum")[0]["sum"]
         area = await get_area_of_bpolys(self.feature.geometry)
 
         if pop_count is None:

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
@@ -1,18 +1,17 @@
 import logging
-import os
 from io import StringIO
 from string import Template
 
 import dateutil.parser
 import matplotlib.pyplot as plt
 import numpy as np
-import rasterstats
 from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
 from ohsome_quality_analyst.geodatabase.client import get_area_of_bpolys
 from ohsome_quality_analyst.ohsome import client as ohsome_client
-from ohsome_quality_analyst.utils.definitions import get_attribution
+from ohsome_quality_analyst.raster.client import get_zonal_stats
+from ohsome_quality_analyst.utils.definitions import get_attribution, get_raster_dataset
 
 
 class GhsPopComparisonRoads(BaseIndicator):
@@ -50,18 +49,8 @@ class GhsPopComparisonRoads(BaseIndicator):
             return 5
 
     async def preprocess(self) -> None:
-        raster = os.path.abspath(
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "..",
-                "data",
-                "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
-            )
-        )
-        stats = rasterstats.zonal_stats(self.feature, raster, stats="sum")
+        raster = get_raster_dataset("GHS_POP_R2019A")
+        stats = get_zonal_stats(self.feature, raster, stats="sum")
         pop_count = stats[0]["sum"]
         area = await get_area_of_bpolys(self.feature.geometry)
         if pop_count is None:

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
@@ -1,15 +1,16 @@
 import logging
+import os
 from io import StringIO
 from string import Template
 
 import dateutil.parser
 import matplotlib.pyplot as plt
 import numpy as np
-from asyncpg import Record
+import rasterstats
 from geojson import Feature
 
 from ohsome_quality_analyst.base.indicator import BaseIndicator
-from ohsome_quality_analyst.geodatabase import client as db_client
+from ohsome_quality_analyst.geodatabase.client import get_area_of_bpolys
 from ohsome_quality_analyst.ohsome import client as ohsome_client
 from ohsome_quality_analyst.utils.definitions import get_attribution
 
@@ -49,8 +50,20 @@ class GhsPopComparisonRoads(BaseIndicator):
             return 5
 
     async def preprocess(self) -> None:
-        pop_count, area = await self.get_zonal_stats_population()
-
+        raster = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "..",
+                "..",
+                "data",
+                "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
+            )
+        )
+        stats = rasterstats.zonal_stats(self.feature, raster, stats="sum")
+        pop_count = stats[0]["sum"]
+        area = await get_area_of_bpolys(self.feature.geometry)
         if pop_count is None:
             pop_count = 0
         self.area = area
@@ -168,33 +181,3 @@ class GhsPopComparisonRoads(BaseIndicator):
         self.result.svg = img_data.getvalue()
         logging.debug("Successful SVG figure creation")
         plt.close("all")
-
-    async def get_zonal_stats_population(self) -> Record:
-        """Derive zonal population stats for given GeoJSON geometry.
-
-        This is based on the Global Human Settlement Layer Population.
-        """
-        logging.info("Get population inside polygon")
-        query = """
-            SELECT
-            SUM(
-                (public.ST_SummaryStats(
-                    public.ST_Clip(
-                        rast,
-                        st_setsrid(public.ST_GeomFromGeoJSON($1), 4326)
-                    )
-                )
-            ).sum) population
-            ,public.ST_Area(
-                st_setsrid(public.ST_GeomFromGeoJSON($2)::public.geography, 4326)
-            ) / (1000*1000) as area_sqkm
-            FROM ghs_pop
-            WHERE
-             public.ST_Intersects(
-                rast,
-                st_setsrid(public.ST_GeomFromGeoJSON($3), 4326)
-             )
-            """
-        data = tuple([str(self.feature.geometry)] * 3)
-        async with db_client.get_connection() as conn:
-            return await conn.fetchrow(query, *data)

--- a/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/ghs_pop_comparison_roads/indicator.py
@@ -50,8 +50,7 @@ class GhsPopComparisonRoads(BaseIndicator):
 
     async def preprocess(self) -> None:
         raster = get_raster_dataset("GHS_POP_R2019A")
-        stats = get_zonal_stats(self.feature, raster, stats="sum")
-        pop_count = stats[0]["sum"]
+        pop_count = get_zonal_stats(self.feature, raster, stats="sum")[0]["sum"]
         area = await get_area_of_bpolys(self.feature.geometry)
         if pop_count is None:
             pop_count = 0

--- a/workers/tests/integrationtests/test_indicator_ghs_pop_comparison_buildings.py
+++ b/workers/tests/integrationtests/test_indicator_ghs_pop_comparison_buildings.py
@@ -2,8 +2,6 @@ import asyncio
 import unittest
 from datetime import datetime
 
-from asyncpg import Record
-
 from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.indicators.ghs_pop_comparison_buildings.indicator import (
     GhsPopComparisonBuildings,
@@ -42,11 +40,6 @@ class TestIndicatorGhsPopComparisonBuildings(unittest.TestCase):
 
         self.indicator.create_figure()
         self.assertIsNotNone(self.indicator.result.svg)
-
-    @oqt_vcr.use_cassette()
-    def test_get_zonal_stats_population(self):
-        result = asyncio.run(self.indicator.get_zonal_stats_population())
-        self.assertIsInstance(result, Record)
 
 
 if __name__ == "__main__":

--- a/workers/tests/integrationtests/test_indicator_ghs_pop_comparison_roads.py
+++ b/workers/tests/integrationtests/test_indicator_ghs_pop_comparison_roads.py
@@ -2,8 +2,6 @@ import asyncio
 import unittest
 from datetime import datetime
 
-from asyncpg import Record
-
 from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.indicators.ghs_pop_comparison_roads.indicator import (
     GhsPopComparisonRoads,
@@ -41,10 +39,6 @@ class TestIndicatorGhsPopComparisonRoads(unittest.TestCase):
 
         self.indicator.create_figure()
         self.assertIsNotNone(self.indicator.result.svg)
-
-    def test_get_zonal_stats_population(self):
-        result = asyncio.run(self.indicator.get_zonal_stats_population())
-        self.assertIsInstance(result, Record)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Indicators based on GHS_POP raster are now calculated with rasterstats and from raster on the disk instead of the database.

### Corresponding issue
Closes #267

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)