### PR TITLE
Add minimal example using the new HTML output feature

### DIFF
--- a/docs/examples/minimal-example.html
+++ b/docs/examples/minimal-example.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Minimal Example for using the HTML Feature in OQT</title>
+    <script type="text/javascript">
+        // minimal example without proper error handling!
+        function makeRequest(params) {
+            const xmlHttp = new XMLHttpRequest();
+            // result handling
+            xmlHttp.onreadystatechange = function () {
+                if (xmlHttp.readyState !== 4 || xmlHttp.status !== 200) return;
+                const response = JSON.parse(xmlHttp.responseText);
+                document.getElementById('oqt-results').innerHTML = response["properties"]["report.result.html"];
+            }
+            xmlHttp.open("POST", "https://oqt.ohsome.org/api/report");
+            xmlHttp.setRequestHeader('Content-Type', 'application/json');
+            xmlHttp.send(JSON.stringify(params));
+        }
+        const params = {
+            "name": "SimpleReport",
+            "dataset": "regions",
+            "featureId": 3,
+            "includeSvg": false,
+            "includeHtml": true
+        };
+        makeRequest(params);
+    </script>
+</head>
+<body>
+    <h1>Minimal Example for using the HTML Feature in OQT</h1>
+    <div id="oqt-results"></div>
+</body>
+</html>


### PR DESCRIPTION
### Description
This PR adds an example how the new `includeHtml` parameter can be used with JavaScript. This example is not meant for direct use, but as showcase how easy it can be.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- ~[ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
