### PR TITLE
Add missing error handling to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Current Main
+
+### Bug Fixes
+
+- Add missing error handling of `RasterDatasetUndefinedError` and `RasterDatasetNotFoundError` to the API ([#298])
+
+[#298]: https://github.com/GIScience/ohsome-quality-analyst/pull/298
+
+
 ## 0.9.0
 
 ### Breaking Changes

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -108,17 +108,19 @@ async def validation_exception_handler(
     )
 
 
-@app.exception_handler(OhsomeApiError)
-@app.exception_handler(SizeRestrictionError)
 @app.exception_handler(LayerDataSchemaError)
+@app.exception_handler(OhsomeApiError)
+@app.exception_handler(RasterDatasetNotFoundError)
+@app.exception_handler(RasterDatasetUndefinedError)
+@app.exception_handler(SizeRestrictionError)
 async def oqt_exception_handler(
     request: Request,
     exception: Union[
+        LayerDataSchemaError,
         OhsomeApiError,
-        SizeRestrictionError,
         RasterDatasetNotFoundError,
         RasterDatasetUndefinedError,
-        LayerDataSchemaError,
+        SizeRestrictionError,
     ],
 ):
     """Exception handler for custom OQT exceptions."""


### PR DESCRIPTION
### Description
Add missing error handling of `RasterDatasetUndefinedError` and `RasterDatasetNotFoundError` to the API.
Those errors have been introduced in PR #227. By adding those error to the error handling of the API they will be reported back to the user in form of a API response.

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- ~[ ] I have commented my code~
- ~[ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~