### PR TITLE
 Add 'flatten' parameter to API request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### New Features
 
--  Add support for `groupBy/boundary` queries to the ohsome API client ([#272])
+- Add support for `groupBy/boundary` queries to the ohsome API client ([#272])
+- Add `flatten` parameter to API request. Make flatten of GeoJSON properties of Indicators and Reports optional. ([#303])
 
 ### Other Changes
 
@@ -20,6 +21,7 @@
 [#298]: https://github.com/GIScience/ohsome-quality-analyst/pull/298
 [#299]: https://github.com/GIScience/ohsome-quality-analyst/pull/299
 [#302]: https://github.com/GIScience/ohsome-quality-analyst/pull/302
+[#303]: https://github.com/GIScience/ohsome-quality-analyst/pull/303
 [#310]: https://github.com/GIScience/ohsome-quality-analyst/pull/310
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,6 +26,7 @@ Depending on the input, the output will be a GeoJSON Feature or FeatureCollectio
 | `layer`       | Name, description and data of a custom layer. Data has to be provided in the same format as the response of the ohsome API would look like        |
 | `includeSvg`  | Include a SVG string of a figure displaying the Indicator results                                                                                 |
 | `includeHtml` | Include a HTML string with the Indicator results                                                                                                  |
+| `flatten`     | Flattening of the GeoJSON properties                                                                                                              |
 
 Parameters are in part mutual exclusive (e.g. either `dataset` and `featureId` or `bpolys`). If the response contains multiple errors probably not all required parameters and/or mutual exclusive parameters have been provided.
 
@@ -49,6 +50,7 @@ parameters = {
     "fidField": "ogc_fid",  # Optional
     "includeSvg": False,  # Optional
     "includeHtml": False,  # Optional
+    "flatten": True,  # Optional
 }
 # Response using the GET method
 response = requests.get(url, params=parameters)
@@ -80,6 +82,7 @@ parameters = {
     "bpolys": bpolys,
     "includeSvg": False,  # Optional
     "includeHtml": False,  # Optional
+    "flatten": True,  # Optional
 }
 response = requests.post(url, json=parameters)
 ```
@@ -157,6 +160,7 @@ parameters = {
     "layer": layer,
     "includeSvg": False,  # Optional
     "includeHtml": False,  # Optional
+    "flatten": True,  # Optional
 }
 response = requests.post(url, json=parameters)
 ```
@@ -215,6 +219,7 @@ Depending on the input, the output will be a GeoJSON Feature or FeatureCollectio
 | `bpolys`      | Bounding polygon(s) as GeoJSON Feature, FeatureCollection, Polygon or MultiPolygon object. The Geometry has to be of type Polygon or MultiPolygon |
 | `includeSvg`  | Include a SVG string of a figure displaying the Indicator results                                                                                 |
 | `includeHtml` | Include a HTML string with the Indicator results                                                                                                  |
+| `flatten`     | Flattening of the GeoJSON properties                                                                                                              |
 
 Some parameters are mutually exclusive (E.g. either `dataset` and `featureId` or `bpolys`). If the response contains multiple errors, it is likely that not all required parameters and/or mutually exclusive parameters have been provided.
 
@@ -236,6 +241,7 @@ parameters = {
     "featureId": 3,
     "includeSvg": False,  # Optional
     "includeHtml": False,  # Optional
+    "flatten": True,  # Optional
 }
 # Response using the GET method
 response = requests.get(url, params=parameters)
@@ -266,6 +272,7 @@ parameters = {
     "bpolys": bpolys,
     "includeSvg": False,  # Optional
     "includeHtml": False,  # Optional
+    "flatten": True,  # Optional
 }
 response = requests.post(url, json=parameters)
 ```

--- a/workers/ohsome_quality_analyst/api/request_models.py
+++ b/workers/ohsome_quality_analyst/api/request_models.py
@@ -38,6 +38,7 @@ class BaseIndicator(BaseModel):
     )
     include_svg: bool = False
     include_html: bool = False
+    flatten: bool = True
 
     class Config:
         """Pydantic config class."""
@@ -51,6 +52,7 @@ class BaseReport(BaseModel):
     name: ReportEnum = pydantic.Field(..., title="Report Name", example="SimpleReport")
     include_svg: bool = False
     include_html: bool = False
+    flatten: bool = True
 
     class Config:
         """Pydantic config class."""
@@ -186,6 +188,7 @@ INDICATOR_EXAMPLES = {
             "fidField": "ogc_fid",
             "includeSvg": False,
             "includeHtml": False,
+            "flatten": True,
         },
     },
     "Custom AOI": {
@@ -233,6 +236,7 @@ INDICATOR_EXAMPLES = {
                 },
                 "includeSvg": False,
                 "includeHtml": False,
+                "flatten": True,
             },
             "layer": {
                 "name": "My layer name",
@@ -281,6 +285,7 @@ INDICATOR_EXAMPLES = {
             },
             "includeSvg": False,
             "includeHtml": False,
+            "flatten": True,
         },
     },
 }
@@ -297,6 +302,7 @@ REPORT_EXAMPLES = {
             "fidField": "ogc_fid",
             "includeSvg": False,
             "includeHtml": False,
+            "flatten": True,
         },
     },
     "Custom AOI": {
@@ -320,6 +326,7 @@ REPORT_EXAMPLES = {
             },
             "includeSvg": False,
             "includeHtml": False,
+            "flatten": True,
         },
     },
 }

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -68,7 +68,7 @@ async def _(
         if size_restriction:
             await check_area_size(feature.geometry)
         indicator = await create_indicator(parameters.copy(update={"bpolys": feature}))
-        features.append(indicator.as_feature(flatten=True))
+        features.append(indicator.as_feature(flatten=parameters.flatten))
     if len(features) == 1:
         return features[0]
     else:
@@ -83,7 +83,7 @@ async def _(
 ) -> Feature:
     """Create an indicator as GeoJSON object."""
     indicator = await create_indicator(parameters, force)
-    return indicator.as_feature(flatten=True)
+    return indicator.as_feature(flatten=parameters.flatten)
 
 
 async def create_report_as_geojson(
@@ -111,14 +111,14 @@ async def create_report_as_geojson(
                 parameters.copy(update={"bpolys": feature}),
                 force,
             )
-            features.append(report.as_feature())
+            features.append(report.as_feature(flatten=parameters.flatten))
         if len(features) == 1:
             return features[0]
         else:
             return FeatureCollection(features=features)
     elif isinstance(parameters, ReportDatabase):
         report = await create_report(parameters, force)
-        return report.as_feature()
+        return report.as_feature(flatten=parameters.flatten)
     else:
         raise ValueError("Unexpected parameters: " + str(parameters))
 

--- a/workers/tests/integrationtests/test_api_indicator.py
+++ b/workers/tests/integrationtests/test_api_indicator.py
@@ -240,6 +240,35 @@ class TestApiIndicator(unittest.TestCase):
         result = response.json()
         self.assertNotIn("result.html", list(result["properties"].keys()))
 
+    @oqt_vcr.use_cassette()
+    def test_indicator_flatten_default(self):
+        url = "/indicator?name={0}&layerName={1}&dataset={2}" "&featureId={3}".format(
+            self.indicator_name,
+            self.layer_name,
+            self.dataset,
+            self.feature_id,
+        )
+        response = self.client.get(url)
+        result = response.json()
+        # Check flat result value
+        self.assertIn("result.value", result["properties"].keys())
+
+    @oqt_vcr.use_cassette()
+    def test_indicator_flatten_true(self):
+        url = (
+            "/indicator?name={0}&layerName={1}&dataset={2}"
+            "&featureId={3}&flatten={4}".format(
+                self.indicator_name,
+                self.layer_name,
+                self.dataset,
+                self.feature_id,
+                False,
+            )
+        )
+        response = self.client.get(url)
+        result = response.json()
+        self.assertIn("value", result["properties"]["result"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/workers/tests/integrationtests/test_base_report.py
+++ b/workers/tests/integrationtests/test_base_report.py
@@ -20,7 +20,7 @@ class TestBaseReport(unittest.TestCase):
         for _ in report.indicator_layer:
             report.indicators.append(indicator)
 
-        feature = report.as_feature()
+        feature = report.as_feature(flatten=True)
         self.assertTrue(feature.is_valid)
 
         for i in (

--- a/workers/tests/unittests/test_api.py
+++ b/workers/tests/unittests/test_api.py
@@ -5,7 +5,7 @@ import geojson
 from ohsome_quality_analyst import __version__ as oqt_version
 from ohsome_quality_analyst.api.api import (
     empty_api_response,
-    remove_item_from_properties,
+    remove_result_item_from_properties,
 )
 
 
@@ -22,14 +22,23 @@ class TestApi(unittest.TestCase):
         }
         self.assertDictEqual(response_template, empty_api_response())
 
-    def test_remove_item_from_properties_feature(self):
+    def test_remove_item_from_properties_feature_flatten(self):
         geom = geojson.utils.generate_random("Polygon")
         prop = {"test": "test", "result.svg": "123", "result.label": "green"}
         feature = geojson.Feature(geometry=geom, properties=prop)
-        remove_item_from_properties(feature, "*result.svg")
+        remove_result_item_from_properties(feature, "svg", True)
         self.assertNotIn("result.svg", list(feature["properties"].keys()))
+        self.assertIn("result.label", list(feature["properties"].keys()))
 
-    def test_remove_item_from_properties_feature_collection(self):
+    def test_remove_item_from_properties_feature(self):
+        geom = geojson.utils.generate_random("Polygon")
+        prop = {"test": "test", "result": {"svg": "123", "label": "green"}}
+        feature = geojson.Feature(geometry=geom, properties=prop)
+        remove_result_item_from_properties(feature, "svg", False)
+        self.assertNotIn("svg", list(feature["properties"]["result"].keys()))
+        self.assertIn("label", list(feature["properties"]["result"].keys()))
+
+    def test_remove_item_from_properties_feature_collection_flatten(self):
         geom_1 = geojson.utils.generate_random("Polygon")
         geom_2 = geojson.utils.generate_random("Polygon")
         prop_1 = {"0.result.svg": "123", "result.label": "green"}
@@ -37,6 +46,20 @@ class TestApi(unittest.TestCase):
         feature_1 = geojson.Feature(geometry=geom_1, properties=prop_1)
         feature_2 = geojson.Feature(geometry=geom_2, properties=prop_2)
         feature_collection = geojson.FeatureCollection([feature_1, feature_2])
-        remove_item_from_properties(feature_collection, "*result.svg")
+        remove_result_item_from_properties(feature_collection, "svg", True)
         for element in feature_collection["features"]:
             self.assertNotIn("result.svg", list(element["properties"].keys()))
+            self.assertIn("result.label", list(element["properties"].keys()))
+
+    def test_remove_item_from_properties_feature_collection(self):
+        geom_1 = geojson.utils.generate_random("Polygon")
+        geom_2 = geojson.utils.generate_random("Polygon")
+        prop_1 = {"result": {"svg": "123", "label": "green"}}
+        prop_2 = {"result": {"svg": "abv", "label": "green"}}
+        feature_1 = geojson.Feature(geometry=geom_1, properties=prop_1)
+        feature_2 = geojson.Feature(geometry=geom_2, properties=prop_2)
+        feature_collection = geojson.FeatureCollection([feature_1, feature_2])
+        remove_result_item_from_properties(feature_collection, "svg", False)
+        for element in feature_collection["features"]:
+            self.assertNotIn("svg", list(element["properties"]["result"].keys()))
+            self.assertIn("label", list(element["properties"]["result"].keys()))

--- a/workers/tests/unittests/test_api_request_models.py
+++ b/workers/tests/unittests/test_api_request_models.py
@@ -21,7 +21,12 @@ class TestApiRequestModels(unittest.TestCase):
 
     def test_base_indicator_valid(self):
         request_models.BaseIndicator(name="GhsPopComparisonBuildings")
-        request_models.BaseIndicator(name="GhsPopComparisonBuildings", includeSvg=True)
+        request_models.BaseIndicator(
+            name="GhsPopComparisonBuildings",
+            includeSvg=True,
+            includeHtml=True,
+            flatten=False,
+        )
 
     def test_base_indicator_invalid(self):
         with self.assertRaises(ValueError):
@@ -31,10 +36,21 @@ class TestApiRequestModels(unittest.TestCase):
             request_models.BaseIndicator(
                 name="GhsPopComparisonBuildings", include_svg="foo"
             )
+            request_models.BaseIndicator(
+                name="GhsPopComparisonBuildings", include_html="foo"
+            )
+            request_models.BaseIndicator(
+                name="GhsPopComparisonBuildings", flatten="foo"
+            )
 
     def test_base_report_valid(self):
         request_models.BaseReport(name="SimpleReport")
-        request_models.BaseReport(name="SimpleReport", includeSvg=True)
+        request_models.BaseReport(
+            name="SimpleReport",
+            includeSvg=True,
+            includeHtml=True,
+            flatten=False,
+        )
 
     def test_base_report_invalid(self):
         with self.assertRaises(ValueError):
@@ -42,6 +58,8 @@ class TestApiRequestModels(unittest.TestCase):
             request_models.BaseReport(name="foo")
             request_models.BaseReport(include_svg=True)
             request_models.BaseReport(name="SimpleReport", includeSvg="foo")
+            request_models.BaseReport(name="SimpleReport", includeHtml="foo")
+            request_models.BaseReport(name="SimpleReport", flatten="foo")
 
     def test_layer_name_valid(self):
         # Test on BaseIndicator because validation of BaseLayer needs indicator name

--- a/workers/tests/unittests/test_api_request_models.py
+++ b/workers/tests/unittests/test_api_request_models.py
@@ -31,14 +31,19 @@ class TestApiRequestModels(unittest.TestCase):
     def test_base_indicator_invalid(self):
         with self.assertRaises(ValueError):
             request_models.BaseIndicator()
+        with self.assertRaises(ValueError):
             request_models.BaseIndicator(name="foo")
+        with self.assertRaises(ValueError):
             request_models.BaseIndicator(includeSvg=True)
+        with self.assertRaises(ValueError):
             request_models.BaseIndicator(
                 name="GhsPopComparisonBuildings", include_svg="foo"
             )
+        with self.assertRaises(ValueError):
             request_models.BaseIndicator(
                 name="GhsPopComparisonBuildings", include_html="foo"
             )
+        with self.assertRaises(ValueError):
             request_models.BaseIndicator(
                 name="GhsPopComparisonBuildings", flatten="foo"
             )
@@ -55,10 +60,15 @@ class TestApiRequestModels(unittest.TestCase):
     def test_base_report_invalid(self):
         with self.assertRaises(ValueError):
             request_models.BaseReport()
+        with self.assertRaises(ValueError):
             request_models.BaseReport(name="foo")
+        with self.assertRaises(ValueError):
             request_models.BaseReport(include_svg=True)
+        with self.assertRaises(ValueError):
             request_models.BaseReport(name="SimpleReport", includeSvg="foo")
+        with self.assertRaises(ValueError):
             request_models.BaseReport(name="SimpleReport", includeHtml="foo")
+        with self.assertRaises(ValueError):
             request_models.BaseReport(name="SimpleReport", flatten="foo")
 
     def test_layer_name_valid(self):
@@ -146,6 +156,7 @@ class TestApiRequestModels(unittest.TestCase):
         }
         with self.assertRaises(ValueError):
             request_models.IndicatorDatabase(**kwargs)
+        with self.assertRaises(ValueError):
             request_models.IndicatorBpolys(**kwargs)
 
     def test_indicator_data(self):


### PR DESCRIPTION
### Description

Make flatten of GeoJSON properties of Indicators and Reports optional.

### Corresponding issue

Continue work of #247 
Closes #281 

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)