### PR TITLE
Disable size limit for requests with data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Factor out template logic to own module ([#302])
 - Remove artifacts of database setup for GHSL raster datasets ([#310])
 - Add hex-cells at zoom level 12 for Africa to the database ([#314])
+- Disable size limit on input AOI if OSM data is provided through a request with a custom Layer object ([#330])
 
 [#272]: https://github.com/GIScience/ohsome-quality-analyst/pull/272
 [#298]: https://github.com/GIScience/ohsome-quality-analyst/pull/298
@@ -27,6 +28,7 @@
 [#307]: https://github.com/GIScience/ohsome-quality-analyst/pull/307
 [#310]: https://github.com/GIScience/ohsome-quality-analyst/pull/310
 [#314]: https://github.com/GIScience/ohsome-quality-analyst/pull/314
+[#330]: https://github.com/GIScience/ohsome-quality-analyst/pull/330
 
 
 ## 0.9.0

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -67,7 +67,8 @@ async def _(
         else:
             id_ = str(i)
         logging.info("Input feature identifier: " + id_)
-        if size_restriction:
+        # Only enforce size limit if ohsome API data is not provided
+        if size_restriction and isinstance(parameters, IndicatorBpolys):
             await check_area_size(feature.geometry)
         tasks.append(
             sem_task(create_indicator(parameters.copy(update={"bpolys": feature})))


### PR DESCRIPTION
### Description
Only enforce size limit on input AOI if ohsome API needs to be queried.
If OSM data is provided through a request with a custom Layer object
disable the size restriction.

### Corresponding issue
None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)