### PR TITLE
support FeatureCollections for func `get_shdi`

### DIFF
--- a/workers/ohsome_quality_analyst/geodatabase/select_shdi.sql
+++ b/workers/ohsome_quality_analyst/geodatabase/select_shdi.sql
@@ -1,6 +1,11 @@
 WITH bpoly AS (
     SELECT
-        ST_Setsrid (public.ST_GeomFromGeoJSON ($1), 4326) AS geom
+        ST_Setsrid (public.ST_GeomFromGeoJSON (geojson), 4326) AS geom,
+        -- Row number is used to make sure order of result is the same as order of input
+        -- (Probably unnecessary)
+        row_number() OVER () AS rownumber
+    FROM
+        unnest(cast($1 AS text[])) AS geojson
 )
 SELECT
     SUM(ST_Area (ST_Intersection (shdi.geom, bpoly.geom)::geography) / ST_Area
@@ -9,4 +14,9 @@ FROM
     shdi,
     bpoly
 WHERE
-    ST_Intersects (shdi.geom, bpoly.geom);
+    ST_Intersects (shdi.geom, bpoly.geom)
+GROUP BY
+    bpoly.geom,
+    bpoly.rownumber
+ORDER BY
+    bpoly.rownumber;

--- a/workers/tests/integrationtests/test_geodatabase.py
+++ b/workers/tests/integrationtests/test_geodatabase.py
@@ -8,7 +8,7 @@ from ohsome_quality_analyst.indicators.ghs_pop_comparison_buildings.indicator im
     GhsPopComparisonBuildings,
 )
 
-from .utils import get_layer_fixture, oqt_vcr
+from .utils import get_geojson_fixture, get_layer_fixture, oqt_vcr
 
 
 class TestGeodatabase(unittest.TestCase):
@@ -140,11 +140,27 @@ class TestGeodatabase(unittest.TestCase):
         )
         self.assertEqual(result, "3")
 
-    def test_get_shdi_single_intersection(self):
+    def test_get_shdi_single_intersection_feature(self):
         """Input geometry intersects only with one SHDI region."""
-        shdi = asyncio.run(db_client.get_shdi(self.feature.geometry))
-        self.assertIsInstance(shdi, float)
-        self.assertLessEqual(shdi, 1.0)
+        result = asyncio.run(db_client.get_shdi(self.feature))
+        self.assertIsInstance(result[0]["shdi"], float)
+        self.assertLessEqual(result[0]["shdi"], 1.0)
+        self.assertEqual(len(result), 1)
+
+    def test_get_shdi_single_intersection_featurecollection(self):
+        featurecollection = get_geojson_fixture(
+            "heidelberg-bahnstadt-bergheim-featurecollection.geojson"
+        )
+        result = asyncio.run(db_client.get_shdi(featurecollection))
+        self.assertIsInstance(result[0]["shdi"], float)
+        self.assertLessEqual(result[0]["shdi"], 1.0)
+        self.assertIsInstance(result[1]["shdi"], float)
+        self.assertLessEqual(result[1]["shdi"], 1.0)
+        self.assertEqual(len(result), 2)
+
+    def test_get_shdi_type_error(self):
+        with self.assertRaises(TypeError):
+            asyncio.run(db_client.get_shdi(self.feature.geometry))
 
     # Note: This test can only be executed if the whole SHDI is in the database.
     # def test_get_shdi_multiple_intersections(self):
@@ -160,9 +176,9 @@ class TestGeodatabase(unittest.TestCase):
     #             ]
     #         ],
     #     )
-    #     shdi = asyncio.run(db_client.get_shdi(geom))
-    #     self.assertIsInstance(shdi, float)
-    #     self.assertLessEqual(shdi, 1.0)
+    #     result = asyncio.run(db_client.get_shdi(geom))
+    #     self.assertIsInstance(result[0]["shdi"], float)
+    #     self.assertLessEqual(result[0]["shdi"], 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
previously `get_shdi` worked only for one feature (one geometry). This PR adds support for FeatureCollections (multiple geoms). This is useful when requesting SHDI for multiple hex-cells for example.

### Corresponding issue
None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
~- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~