### PR TITLE
fix validation of groupBy responses of ohsome API

### DIFF
--- a/workers/ohsome_quality_analyst/ohsome/client.py
+++ b/workers/ohsome_quality_analyst/ohsome/client.py
@@ -52,7 +52,6 @@ async def _(
         count_latest_contributions:  Count of the latest contributions provided to the
             OSM data.
     """
-
     url = build_url(layer, ratio, group_by_boundary, count_latest_contributions)
     data = build_data_dict(layer, bpolys, time, ratio)
     response = await query_ohsome_api(url, data)
@@ -212,7 +211,7 @@ def validate_query_results(
                 schema,
             ],
         }
-        schema["groupByResult"][0]["groupByObject"] = str
+        schema["groupByResult"][0]["groupByObject"] = Or(int, str)
         response_key = "groupByResult"
     Schema(
         schema,


### PR DESCRIPTION
### Description
`groupByObject` value can also be int, not just str.

### Corresponding issue
None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
~- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~