### PR TITLE
download hexcells and shdi SQL files for dev db

### DIFF
--- a/database/init_db.development/schema.dev.sh
+++ b/database/init_db.development/schema.dev.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
+# SQL files will be executed on first start of the database container
 set -e
-
 if [[ $OQT_TEST_DB = False ]]; then
     wget https://downloads.ohsome.org/OQT/schema.dev.sql.gz
     gunzip schema.dev.sql.gz
+    wget https://downloads.ohsome.org/OQT/hexcells.sql.gz
+    gunzip hexcells.sql.gz
+    wget https://downloads.ohsome.org/OQT/shdi.sql.gz
+    gunzip shdi.sql.gz
 fi


### PR DESCRIPTION
### Description
Hexcells for Africa and SHDI world wide are two datasets required for the new Building Area Indicator.
For easy development setup download those datasets during the build of the development database Docker image.
If fast and minimal database setup is desired use `OQT_TEST_DB=True`.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [ ] I have updated my branch to `main` (e.g. through `git rebase main`)
- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)