### PR TITLE
set nodata value of rasters explicitly

### DIFF
--- a/workers/ohsome_quality_analyst/raster/client.py
+++ b/workers/ohsome_quality_analyst/raster/client.py
@@ -29,6 +29,7 @@ def get_zonal_stats(
         transform(feature, raster),
         get_raster_path(raster),
         *args,
+        nodata=raster.nodata,
         **kwargs,
     )
 

--- a/workers/ohsome_quality_analyst/utils/definitions.py
+++ b/workers/ohsome_quality_analyst/utils/definitions.py
@@ -7,7 +7,7 @@ import os
 import sys
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import rpy2.rinterface_lib.callbacks
 import yaml
@@ -48,6 +48,7 @@ class RasterDataset:
     name: str
     filename: str
     crs: str
+    nodata: Optional[int]
 
 
 RASTER_DATASETS = (
@@ -55,21 +56,25 @@ RASTER_DATASETS = (
         "GHS_BUILT_R2018A",
         "GHS_BUILT_LDS2014_GLOBE_R2018A_54009_1K_V2_0.tif",
         "ESRI:54009",
+        -200,
     ),
     RasterDataset(
         "GHS_POP_R2019A",
         "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
         "ESRI:54009",
+        -200,
     ),
     RasterDataset(
         "GHS_SMOD_R2019A",
         "GHS_SMOD_POP2015_GLOBE_R2019A_54009_1K_V2_0.tif",
         "ESRI:54009",
+        -200,
     ),
     RasterDataset(
         "VNL",
         "VNL_v2_npp_2020_global_vcmslcfg_c202102150000.average_masked.tif",
         "EPSG:4326",
+        None,
     ),
 )
 


### PR DESCRIPTION
### Description

Set nodata value of rasters explicitly. This avoids cluttering terminal with UserWarnings of the module `rasterstats`.

```
.cache/pypoetry/virtualenvs/ohsome-quality-analyst-JhxvPu0L-py3.9/lib/python3.9/site-packages/rasterstats/io.py:313: UserWarning: Setting nodata to -999; specify nodata explicitly
    warnings.warn("Setting nodata to -999; specify nodata explicitly")
```

### Corresponding issue
Closes #331 

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
~- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~
