### PR TITLE
fix HTML creation for Indicators calculated from scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Add missing error handling of `RasterDatasetUndefinedError` and `RasterDatasetNotFoundError` to the API ([#298])
+- Fix missing HTML generation for Indicators calculated from scratch (`bpolys` parameter) ([#345])
 
 ### New Features
 
@@ -29,6 +30,7 @@
 [#310]: https://github.com/GIScience/ohsome-quality-analyst/pull/310
 [#314]: https://github.com/GIScience/ohsome-quality-analyst/pull/314
 [#330]: https://github.com/GIScience/ohsome-quality-analyst/pull/330
+[#345]: https://github.com/GIScience/ohsome-quality-analyst/pull/345
 
 
 ## 0.9.0

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -221,6 +221,7 @@ async def _(
     indicator.calculate()
     logging.info("Run figure creation")
     indicator.create_figure()
+    indicator.create_html()
 
     return indicator
 


### PR DESCRIPTION
### Description

HTML has only been created for Indicators created for features of a
dataset in the DB (`dataset` and `fid` parameters).
Create HTML also for Indicators calculated from scratch (`bpolys`)

### Corresponding issue
- None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
~- [ ] I have commented my code~
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
