### PR TITLE
make inclusion of indicator data in response optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Current Main
+
+### Breaking Changes
+
+- Make inclusion of indicator data in response optional ([#370])
+
+### How to Upgrade
+
+- To continue to retrieve additional data of an Indicator or Report provided in an API response, you need to set the parameter `include_data` to `True` when making requests to the API ([#370])
+
+[#370]: https://github.com/GIScience/ohsome-quality-analyst/pull/370
+
 ## 0.10.0
 
 ### Bug Fixes

--- a/workers/ohsome_quality_analyst/api/request_models.py
+++ b/workers/ohsome_quality_analyst/api/request_models.py
@@ -38,6 +38,7 @@ class BaseIndicator(BaseModel):
     )
     include_svg: bool = False
     include_html: bool = False
+    include_data: bool = False
     flatten: bool = True
 
     class Config:
@@ -52,6 +53,7 @@ class BaseReport(BaseModel):
     name: ReportEnum = pydantic.Field(..., title="Report Name", example="SimpleReport")
     include_svg: bool = False
     include_html: bool = False
+    include_data: bool = False
     flatten: bool = True
 
     class Config:

--- a/workers/ohsome_quality_analyst/base/indicator.py
+++ b/workers/ohsome_quality_analyst/base/indicator.py
@@ -80,7 +80,7 @@ class BaseIndicator(metaclass=ABCMeta):
             html="",
         )
 
-    def as_feature(self, flatten: bool = False) -> Feature:
+    def as_feature(self, flatten: bool = False, include_data: bool = False) -> Feature:
         """Return a GeoJSON Feature object.
 
         The properties of the Feature contains the attributes of the indicator.
@@ -88,6 +88,7 @@ class BaseIndicator(metaclass=ABCMeta):
 
         Args:
             flatten (bool): If true flatten the properties.
+            include_data (bool): If true include additional data in the properties.
         """
         properties = {
             "metadata": {
@@ -99,9 +100,10 @@ class BaseIndicator(metaclass=ABCMeta):
                 "description": self.layer.description,
             },
             "result": asdict(self.result),
-            "data": self.data,
             **self.feature.properties,
         }
+        if include_data:
+            properties["data"] = self.data
         if flatten:
             properties = flatten_dict(properties)
         if "id" in self.feature.keys():

--- a/workers/ohsome_quality_analyst/base/report.py
+++ b/workers/ohsome_quality_analyst/base/report.py
@@ -55,7 +55,7 @@ class BaseReport(metaclass=ABCMeta):
         # Results will be written during the lifecycle of the report object (combine())
         self.result = Result(None, None, None, None)
 
-    def as_feature(self, flatten: bool = False) -> Feature:
+    def as_feature(self, flatten: bool = False, include_data: bool = False) -> Feature:
         """Returns a GeoJSON Feature object.
 
         The properties of the Feature contains the attributes of all indicators.
@@ -71,7 +71,9 @@ class BaseReport(metaclass=ABCMeta):
         properties["report"]["metadata"].pop("label_description", None)
 
         for i, indicator in enumerate(self.indicators):
-            properties["indicators"].append(indicator.as_feature()["properties"])
+            properties["indicators"].append(
+                indicator.as_feature(include_data=include_data)["properties"]
+            )
         if flatten:
             properties = flatten_dict(properties)
         if "id" in self.feature.keys():

--- a/workers/ohsome_quality_analyst/geodatabase/client.py
+++ b/workers/ohsome_quality_analyst/geodatabase/client.py
@@ -81,7 +81,7 @@ async def save_indicator_results(
         indicator.result.value,
         indicator.result.description,
         indicator.result.svg,
-        json.dumps(indicator.as_feature(), default=json_serialize),
+        json.dumps(indicator.as_feature(include_data=True), default=json_serialize),
     )
 
     async with get_connection() as conn:
@@ -134,8 +134,9 @@ async def load_indicator_results(
 
     # Write data back to the attributes of the indicator object
     feature = geojson.loads(query_result["feature"])
-    for key, value in feature["properties"]["data"].items():
-        setattr(indicator, key, value)
+    if "data" in feature["properties"]:
+        for key, value in feature["properties"]["data"].items():
+            setattr(indicator, key, value)
     return indicator
 
 

--- a/workers/ohsome_quality_analyst/oqt.py
+++ b/workers/ohsome_quality_analyst/oqt.py
@@ -76,7 +76,9 @@ async def _(
             await check_area_size(feature.geometry)
         tasks.append(create_indicator(parameters.copy(update={"bpolys": feature})))
     indicators = await gather_with_semaphore(tasks)
-    features = [i.as_feature(flatten=parameters.flatten) for i in indicators]
+    features = [
+        i.as_feature(parameters.flatten, parameters.include_data) for i in indicators
+    ]
     if len(features) == 1:
         return features[0]
     else:
@@ -91,7 +93,7 @@ async def _(
 ) -> Feature:
     """Create an indicator as GeoJSON object."""
     indicator = await create_indicator(parameters, force)
-    return indicator.as_feature(flatten=parameters.flatten)
+    return indicator.as_feature(parameters.flatten, parameters.include_data)
 
 
 async def create_report_as_geojson(
@@ -122,14 +124,16 @@ async def create_report_as_geojson(
                 parameters.copy(update={"bpolys": feature}),
                 force,
             )
-            features.append(report.as_feature(flatten=parameters.flatten))
+            features.append(
+                report.as_feature(parameters.flatten, parameters.include_data)
+            )
         if len(features) == 1:
             return features[0]
         else:
             return FeatureCollection(features=features)
     elif isinstance(parameters, ReportDatabase):
         report = await create_report(parameters, force)
-        return report.as_feature(flatten=parameters.flatten)
+        return report.as_feature(parameters.flatten, parameters.include_data)
     else:
         raise ValueError("Unexpected parameters: " + str(parameters))
 

--- a/workers/tests/integrationtests/test_api_indicator.py
+++ b/workers/tests/integrationtests/test_api_indicator.py
@@ -269,6 +269,56 @@ class TestApiIndicator(unittest.TestCase):
         result = response.json()
         self.assertIn("value", result["properties"]["result"])
 
+    @oqt_vcr.use_cassette()
+    def test_indicator_include_data_default(self):
+        url = (
+            "/indicator?name={0}&layerName={1}&dataset={2}"
+            "&featureId={3}&flatten={4}".format(
+                self.indicator_name,
+                self.layer_name,
+                self.dataset,
+                self.feature_id,
+                False,
+            )
+        )
+        response = self.client.get(url)
+        result = response.json()
+        assert "data" not in result["properties"].keys()
+
+    @oqt_vcr.use_cassette()
+    def test_indicator_include_data_true(self):
+        url = (
+            "/indicator?name={0}&layerName={1}&dataset={2}"
+            "&featureId={3}&flatten={4}&includeData={5}".format(
+                self.indicator_name,
+                self.layer_name,
+                self.dataset,
+                self.feature_id,
+                False,
+                True,
+            )
+        )
+        response = self.client.get(url)
+        result = response.json()
+        assert "data" in result["properties"].keys()
+
+    @oqt_vcr.use_cassette()
+    def test_indicator_include_data_false(self):
+        url = (
+            "/indicator?name={0}&layerName={1}&dataset={2}"
+            "&featureId={3}&flatten={4}&includeData={5}".format(
+                self.indicator_name,
+                self.layer_name,
+                self.dataset,
+                self.feature_id,
+                False,
+                False,
+            )
+        )
+        response = self.client.get(url)
+        result = response.json()
+        assert "data" not in result["properties"].keys()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/workers/tests/integrationtests/test_base_indicator.py
+++ b/workers/tests/integrationtests/test_base_indicator.py
@@ -19,28 +19,38 @@ class TestBaseIndicator(unittest.TestCase):
         indicator = GhsPopComparisonBuildings(feature=self.feature, layer=mock.Mock())
 
         feature = indicator.as_feature()
-        self.assertTrue(feature.is_valid)
-        for i in (
+        assert feature.is_valid
+        assert feature.geometry == feature.geometry
+        for prop in ("result", "metadata", "layer"):
+            assert prop in feature["properties"]
+        assert "data" not in feature["properties"]
+
+    def test_as_feature_include_data(self):
+        indicator = GhsPopComparisonBuildings(feature=self.feature, layer=mock.Mock())
+
+        feature = indicator.as_feature(include_data=True)
+        assert feature.is_valid
+        for key in ("result", "metadata", "layer", "data"):
+            assert key in feature["properties"]
+        for key in (
             "pop_count",
             "area",
             "pop_count_per_sqkm",
             "feature_count",
             "feature_count_per_sqkm",
         ):
-            self.assertIn(i, feature["properties"]["data"].keys())
+            assert key in feature["properties"]["data"]
 
     def test_as_feature_flatten(self):
         indicator = GhsPopComparisonBuildings(feature=self.feature, layer=mock.Mock())
         feature = indicator.as_feature(flatten=True)
-        self.assertTrue(feature.is_valid)
-        for i in (
-            "data.pop_count",
-            "data.area",
-            "data.pop_count_per_sqkm",
-            "data.feature_count",
-            "data.feature_count_per_sqkm",
+        assert feature.is_valid
+        for key in (
+            "result.value",
+            "metadata.name",
+            "layer.name",
         ):
-            self.assertIn(i, feature["properties"].keys())
+            assert key in feature["properties"]
 
     def test_data_property(self):
         indicator = GhsPopComparisonBuildings(feature=self.feature, layer=mock.Mock())

--- a/workers/tests/integrationtests/test_base_report.py
+++ b/workers/tests/integrationtests/test_base_report.py
@@ -20,7 +20,7 @@ class TestBaseReport(unittest.TestCase):
         for _ in report.indicator_layer:
             report.indicators.append(indicator)
 
-        feature = report.as_feature(flatten=True)
+        feature = report.as_feature(flatten=True, include_data=True)
         self.assertTrue(feature.is_valid)
 
         for i in (

--- a/workers/tests/integrationtests/test_indicator_mapping_saturation.py
+++ b/workers/tests/integrationtests/test_indicator_mapping_saturation.py
@@ -52,7 +52,7 @@ class TestIndicatorMappingSaturation(unittest.TestCase):
         asyncio.run(indicator.preprocess())
         indicator.calculate()
 
-        indicator_feature = indicator.as_feature()
+        indicator_feature = indicator.as_feature(include_data=True)
         properties = indicator_feature.properties
         self.assertIsNotNone(properties["data"]["best_fit"]["name"])
 
@@ -60,7 +60,7 @@ class TestIndicatorMappingSaturation(unittest.TestCase):
             self.assertFalse(np.isnan(np.sum(fm["fitted_values"])))
             self.assertTrue(np.isfinite(np.sum(fm["fitted_values"])))
 
-        indicator_feature = indicator.as_feature(flatten=True)
+        indicator_feature = indicator.as_feature(flatten=True, include_data=True)
         properties = indicator_feature.properties
         self.assertIsNotNone(properties["data.best_fit.name"])
 

--- a/workers/tests/unittests/test_api_request_models.py
+++ b/workers/tests/unittests/test_api_request_models.py
@@ -25,6 +25,7 @@ class TestApiRequestModels(unittest.TestCase):
             name="GhsPopComparisonBuildings",
             includeSvg=True,
             includeHtml=True,
+            includeData=False,
             flatten=False,
         )
 
@@ -54,6 +55,7 @@ class TestApiRequestModels(unittest.TestCase):
             name="SimpleReport",
             includeSvg=True,
             includeHtml=True,
+            includeData=False,
             flatten=False,
         )
 


### PR DESCRIPTION
### Description
 make inclusion of indicator data in response optional

### Corresponding issue
Closes #359 

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)