### PR TITLE
refactor(api)!: rename endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Per default properties of the GeoJSON response are not flat ([#375])
 - Remove project specific reports `JrcRequirements`, `SketchmapFitness`, and `MapActionPoc` from the website ([#382])
 - Rename API query parameter `layerName` to `layerKey` and API endpoint `listLayerNames` to `listLayerKeys` ([#376])
+- Rename endpoints for listing of indicator, report, layer, dataset and fid-field names ([#397])
 
 ### New Features
 
@@ -28,6 +29,16 @@
 - To continue to retrieve the properties of the GeoJSON API response as flat list, you need to set the API request parameter `flatten` to `True` ([#375])
 - To continue to retrieve additional data of an Indicator or Report provided in an API response, you need to set the API request parameter `include_data` to `True` ([#370])
 - Make sure to rename the API query parameter `layerName` to `layerKey` and API endpoint `listLayerNames` to `listLayerKeys` ([#376])
+- To continue to retrieve the properties of the GeoJSON API response as flat list, you need to set the API request parameter `flattem` to `True` ([#375])
+- Rename endpoints ([#397]):
+| old                          | new                            |
+| ---                          | ---                            |
+| `indicatorLayerCombinations` | `indicator-layer-combinations` |
+| `indicatorNames`             | `indicators`                   |
+| `datasetNames`               | `datasets`                     |
+| `layerNames`                 | `layers`                       |
+| `reportNames`                | `reports`                      |
+| `fidFields`                  | `fid-fields`                   |
 
 [#342]: https://github.com/GIScience/ohsome-quality-analyst/pull/342
 [#356]: https://github.com/GIScience/ohsome-quality-analyst/pull/356
@@ -40,6 +51,7 @@
 [#383]: https://github.com/GIScience/ohsome-quality-analyst/pull/383
 [#385]: https://github.com/GIScience/ohsome-quality-analyst/pull/385
 [#385]: https://github.com/GIScience/ohsome-quality-analyst/pull/392
+[#385]: https://github.com/GIScience/ohsome-quality-analyst/pull/397
 
 
 ## 0.10.1

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -280,47 +280,47 @@ async def get_available_regions(asGeoJSON: bool = False):
         return response
 
 
-@app.get("/indicatorLayerCombinations")
-async def list_indicator_layer_combinations():
-    """List names of available indicator-layer-combinations."""
+@app.get("/indicator-layer-combinations")
+async def get_indicator_layer_combinations():
+    """Get names of available indicator-layer combinations."""
     response = empty_api_response()
     response["result"] = INDICATOR_LAYER
     return response
 
 
-@app.get("/indicatorNames")
-async def list_indicators():
-    """List names of available indicators."""
+@app.get("/indicators")
+async def indicator_names():
+    """Get names of available indicators."""
     response = empty_api_response()
     response["result"] = get_indicator_names()
     return response
 
 
-@app.get("/datasetNames")
-async def list_datasets():
-    """List names of available datasets."""
+@app.get("/datasets")
+async def dataset_names():
+    """Get names of available datasets."""
     response = empty_api_response()
     response["result"] = get_dataset_names_api()
     return response
 
 
-@app.get("/layerKeys")
-async def list_layers():
-    """List names of available layers."""
+@app.get("/layers")
+async def layer_names():
+    """Get names of available layers."""
     response = empty_api_response()
     response["result"] = get_layer_keys()
     return response
 
 
-@app.get("/reportNames")
-async def list_reports():
-    """List names of available reports."""
+@app.get("/reports")
+async def report_names():
+    """Get names of available reports."""
     response = empty_api_response()
     response["result"] = get_report_names()
     return response
 
 
-@app.get("/fidFields")
+@app.get("/fid-fields")
 async def list_fid_fields():
     """List available fid fields for each dataset."""
     response = empty_api_response()

--- a/workers/tests/integrationtests/test_api.py
+++ b/workers/tests/integrationtests/test_api.py
@@ -51,14 +51,14 @@ class TestApi(unittest.TestCase):
             self.assertIsInstance(region, dict)
 
     def test_list_indicator_layer_combinations(self):
-        url = "/indicatorLayerCombinations"
+        url = "/indicator-layer-combinations"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         self.assertIsInstance(response.json(), dict)
 
     def test_list_indicators(self):
-        url = "/indicatorNames"
+        url = "/indicators"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -67,7 +67,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(self.result_schema.is_valid(response_content))
 
     def test_list_layers(self):
-        url = "/layerKeys"
+        url = "/layers"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -76,7 +76,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(self.result_schema.is_valid(response_content))
 
     def test_list_datasets(self):
-        url = "/datasetNames"
+        url = "/datasets"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -85,7 +85,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(self.result_schema.is_valid(response_content))
 
     def test_list_fid_field(self):
-        url = "/fidFields"
+        url = "/fid-fields"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -94,7 +94,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(self.result_schema.is_valid(response_content))
 
     def test_list_reports(self):
-        url = "/reportNames"
+        url = "/reports"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 


### PR DESCRIPTION

### Description
BREAKING CHANGE: Rename endpoints for listing of indicator,
report, layer, dataset and fid-field names.

### Corresponding issue
Closes https://github.com/GIScience/ohsome-quality-analyst/issues/162

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
