### PR TITLE
fix: building completeness figure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Substitute Simple Report with a Report named Minimal for testing purposes ([#342] [#385])
 - Add a minimal Indicator for testing purposes ([#383])
 - Remove database scripts ([#392])
+- fix: building completeness figure  ([#410])
 
 ### How to Upgrade
 
@@ -65,6 +66,7 @@
 [#392]: https://github.com/GIScience/ohsome-quality-analyst/pull/392
 [#396]: https://github.com/GIScience/ohsome-quality-analyst/pull/396
 [#397]: https://github.com/GIScience/ohsome-quality-analyst/pull/397
+[#410]: https://github.com/GIScience/ohsome-quality-analyst/pull/410
 
 
 ## 0.10.1

--- a/workers/ohsome_quality_analyst/indicators/building_completeness/indicator.py
+++ b/workers/ohsome_quality_analyst/indicators/building_completeness/indicator.py
@@ -173,8 +173,8 @@ class BuildingCompleteness(BaseIndicator):
         ax.yaxis.set_major_formatter(mtick.PercentFormatter(10))
         _, _, patches = ax.hist(
             [i for i in self.completeness_ratio],
-            bins=10,
-            range=(0, 1),
+            bins=15,  # to account for overprediction (>100% completeness)
+            range=(0, 1.5),
             density=True,
             weights=self.building_area_prediction,
             edgecolor="black",
@@ -197,7 +197,7 @@ class BuildingCompleteness(BaseIndicator):
         )
         ax.legend(loc="lower center", bbox_to_anchor=(0.5, -0.45))
         # has to be executed after "major formatter setting"
-        plt.xlim(0, 1)
+        plt.xlim(0, 1.5)
         plt.ylim(0, 10)
         img_data = StringIO()
         plt.savefig(img_data, format="svg", bbox_inches="tight")


### PR DESCRIPTION
### Description

figure did not display completeness ratio over 100%.
Now figure figure will display completeness ratio up to 150%.

### Corresponding issue
None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
~- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
