### PR TITLE
Update api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -110,8 +110,8 @@ bpolys = {
     ],
 }
 layer = {
-    "name": "My layer name"
-    "description": "My layer description"
+    "name": "My layer name",
+    "description": "My layer description",
     "data": {
         "result": [
             {"timestamp": "2014-01-01T00:00:00Z", "value": 4708},
@@ -155,7 +155,7 @@ layer = {
     }
 }
 parameters = {
-    "name": "GhsPopComparisonBuildings",
+    "name": "MappingSaturation",
     "bpolys": bpolys,
     "layer": layer,
     "includeSvg": False,  # Optional


### PR DESCRIPTION
### Description
On the "Request an Indicator for a custom AOI and Layer using Python and `requests` Library" example., the custom Layer call only seems to be supported for the Mapping Saturation indicator. Replaced the GhsPopComparisonBuildings indicator that was originally so this example can work directly. Also added commas that were missing on the layer definition.