### PR TITLE
Temporary fix for sonar-scanner node version

### DIFF
--- a/workers/Dockerfile.continuous-integration
+++ b/workers/Dockerfile.continuous-integration
@@ -1,6 +1,11 @@
 FROM oqt-workers:latest
 
 USER root:root
+
+# temporary fix, due to sonar-scanner requiring node ≥ 14 which is only available in Debian bookworm (testing)
+RUN bash -c 'echo "deb https://deb.nodesource.com/node_14.x focal main" > /etc/apt/sources.list.d/nodesource.list && \
+             curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key > /etc/apt/trusted.gpg.d/nodesource.asc'
+
 # install pg_isready to be able to check if database is ready to be used
 # install java and node for sonar-scanner
 RUN apt-get update && \


### PR DESCRIPTION
### Description
Node version has to be ≥ 14 for sonar-scanner, received directly from nodesource.com

### Corresponding issue
None

### New or changed dependencies
None (in CI Node ≥ 14)

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- ~[ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing~
- [x] I have commented my code
- ~[ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
