### PR TITLE
fix: change layer names to avoid duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Bug Fixes
 
 - Fix patch colorization of Currentness indicator plot ([#432])
+- Rename duplicated layer name `Major Roads` to `Major Roads Count` and `Major Roads Length`. Results are stored in database using the layer name as part of the primary key. ([#438])
 
 [#432]: https://github.com/GIScience/ohsome-quality-analyst/pull/432
+[#438]: https://github.com/GIScience/ohsome-quality-analyst/pull/438
 
 
 ## 0.12.0

--- a/workers/ohsome_quality_analyst/ohsome/layer_definitions.yaml
+++ b/workers/ohsome_quality_analyst/ohsome/layer_definitions.yaml
@@ -19,7 +19,7 @@ building_area:
   filter: building=* and geometry:polygon
 
 major_roads_count:
-  name: Major Roads
+  name: Major Roads Count
   description: |
     The road network defined by all objects which hold the principal tags for
     the road network as defined in the OSM Wiki`:`
@@ -35,7 +35,7 @@ major_roads_count:
     unclassified, residential) and type:way and name=* and name!=""
 
 major_roads_length:
-  name: Major Roads
+  name: Major Roads Length
   description: |
     The road network defined by all objects which hold the principal tags for
     the road network and their link roads as defined in the OSM Wiki`:`


### PR DESCRIPTION
Rename duplicated layer name `Major Roads` to `Major Roads Count` and `Major Roads Length`. Results are stored in database using the layer name as part of the primary key.
