### PR TITLE
fixed broken link to development_setup.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Are you looking to add a new layer? Then please have a look at [docs/layer.md](/
 
 ## Development
 
-Please refer to [this document](docs/development_setup.md](/docs/development_setup.md) for a guide on how to setup OQT for development.
+Please refer to [this document](/docs/development_setup.md) for a guide on how to setup OQT for development.
 
 ## Components
 


### PR DESCRIPTION
Fixes broken link from README to doc describing the development setup
Please add a clear and concise description of what your PR solves.


### Checklist
- [ ] I have updated my branch to `main` (e.g. through `git rebase main`)
- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)

