### PR TITLE
fix: delete duplicated layer supermarkets

### DIFF
--- a/workers/ohsome_quality_analyst/ohsome/layer_definitions.yaml
+++ b/workers/ohsome_quality_analyst/ohsome/layer_definitions.yaml
@@ -457,12 +457,6 @@ restaurants:
   endpoint: elements/count
   filter: amenity=restaurant or amenity=cafe
 
-supermarkets:
-  name: Supermarkets
-  description: Count of supermarkets
-  endpoint: elements/count
-  filter: shop=supermarket
-
 convenience_stores:
   name: Convenience stores
   description: Count of convenience stores


### PR DESCRIPTION
### Description
There are two identical layers called supermarkets.
