### PR TITLE
fix: add timeout for ohsome API metadata requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Bug Fixes
 
 - mapping-saturation: add missing edge case detection for too few data points. ([#512])
+- currentness: add appropriate timeout for ohsome API metadata requests ([#537])
 
 ### New Features
 
@@ -86,6 +87,7 @@
 [#531]: https://github.com/GIScience/ohsome-quality-analyst/pull/531
 [#533]: https://github.com/GIScience/ohsome-quality-analyst/pull/533
 [#536]: https://github.com/GIScience/ohsome-quality-analyst/pull/536
+[#537]: https://github.com/GIScience/ohsome-quality-analyst/pull/537
 
 ## 0.14.1
 

--- a/workers/ohsome_quality_analyst/ohsome/client.py
+++ b/workers/ohsome_quality_analyst/ohsome/client.py
@@ -126,7 +126,8 @@ async def get_latest_ohsome_timestamp() -> datetime.datetime:
     """Get latest unix timestamp from the ohsome API."""
     url = get_config_value("ohsome_api").rstrip("/") + "/metadata"
     headers = {"user-agent": get_config_value("user_agent")}
-    async with httpx.AsyncClient() as client:
+    # 660s timeout for reading, and a 300s timeout elsewhere.
+    async with httpx.AsyncClient(timeout=httpx.Timeout(300, read=660)) as client:
         resp = await client.get(url=url, headers=headers)
     strtime = resp.json()["extractRegion"]["temporalExtent"]["toTimestamp"]
     return datetime.datetime.strptime(strtime, "%Y-%m-%dT%H:%MZ")


### PR DESCRIPTION
### Description
The metadata requests to the ohsome API got a timeout error, because the default `httpx` timeout was used.

### Corresponding issue
Closes #537

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)