### PR TITLE
fix(api): replace attribution URL path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - build: update minimal python version to 3.10 ([#531])
 - build: update dev dependencies ([#531])
 - mapping-saturation: substitute matplotlib SVG with plotly SVG ([#536])
+- api: fix attribution URL path ([#543])
 
 ### How to Upgrade
 
@@ -86,6 +87,7 @@
 [#531]: https://github.com/GIScience/ohsome-quality-analyst/pull/531
 [#533]: https://github.com/GIScience/ohsome-quality-analyst/pull/533
 [#536]: https://github.com/GIScience/ohsome-quality-analyst/pull/536
+[#543]: https://github.com/GIScience/ohsome-quality-analyst/pull/543
 
 ## 0.14.2
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,7 +285,7 @@ response = requests.post(url, json=parameters)
 {
   "apiVersion": "0.11.0",
   "attribution": {
-    "url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    "url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
     "text": "© OpenStreetMap contributors"
   },
   "type": "Feature",

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -72,8 +72,7 @@ ATTRIBUTION_TEXTS = MappingProxyType(
 )
 
 ATTRIBUTION_URL = (
-    "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/"
-    + "COPYRIGHTS.md"
+    "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md"
 )
 
 

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -17,7 +17,7 @@ def response_template():
         "attribution": {
             "url": (
                 "https://github.com/GIScience/ohsome-quality-analyst/blob/main/"
-                + "data/COPYRIGHTS.md"
+                + "COPYRIGHTS.md"
             ),
         },
     }

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_indicator.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_indicator.yaml
@@ -77,7 +77,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -134,7 +134,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -191,7 +191,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -287,7 +287,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -344,7 +344,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -401,7 +401,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -459,7 +459,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -516,7 +516,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -574,7 +574,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -631,7 +631,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -834,7 +834,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -891,7 +891,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_indicator_geojson_io.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_indicator_geojson_io.yaml
@@ -79,7 +79,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -254,7 +254,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "FeatureCollection", "features":
       [{"type": "Feature", "id": 1, "geometry": {"type": "Polygon", "coordinates":
       [[[8.656512, 49.411047], [8.658857, 49.410217], [8.662864, 49.408734], [8.662656,
@@ -319,7 +319,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -391,7 +391,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -767,7 +767,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -807,7 +807,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -980,7 +980,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_report.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_report.yaml
@@ -512,7 +512,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -590,7 +590,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -667,7 +667,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -745,7 +745,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2670,7 +2670,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2748,7 +2748,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2829,7 +2829,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_report_geojson_io.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_api_report_geojson_io.yaml
@@ -547,7 +547,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1551,7 +1551,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "FeatureCollection", "features":
       [{"type": "Feature", "id": 1, "geometry": {"type": "Polygon", "coordinates":
       [[[8.656512, 49.411047], [8.658857, 49.410217], [8.662864, 49.408734], [8.662656,
@@ -1657,7 +1657,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1750,7 +1750,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1811,7 +1811,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -3559,7 +3559,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -3620,7 +3620,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_indicator.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_indicator.yaml
@@ -20,7 +20,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -77,7 +77,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -134,7 +134,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -230,7 +230,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -287,7 +287,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -344,7 +344,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -402,7 +402,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -459,7 +459,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -517,7 +517,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -574,7 +574,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -777,7 +777,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -834,7 +834,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_indicator_geojson_io.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_indicator_geojson_io.yaml
@@ -79,7 +79,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -254,7 +254,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "FeatureCollection", "features":
       [{"type": "Feature", "id": 1, "geometry": {"type": "Polygon", "coordinates":
       [[[8.656512, 49.411047], [8.658857, 49.410217], [8.662864, 49.408734], [8.662656,
@@ -319,7 +319,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -391,7 +391,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -767,7 +767,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -807,7 +807,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -980,7 +980,7 @@ interactions:
     method: POST
     uri: http://testserver/indicator
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_report.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_report.yaml
@@ -20,7 +20,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -98,7 +98,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -175,7 +175,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -253,7 +253,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2178,7 +2178,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2256,7 +2256,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],
@@ -2337,7 +2337,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "geometry":
       {"type": "MultiPolygon", "coordinates": [[[[8.573519, 49.415844], [8.573125,
       49.418096], [8.573602, 49.419967], [8.573137, 49.423648], [8.57776, 49.42532],

--- a/workers/tests/integrationtests/fixtures/vcr_cassettes/test_report_geojson_io.yaml
+++ b/workers/tests/integrationtests/fixtures/vcr_cassettes/test_report_geojson_io.yaml
@@ -547,7 +547,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1551,7 +1551,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "FeatureCollection", "features":
       [{"type": "Feature", "id": 1, "geometry": {"type": "Polygon", "coordinates":
       [[[8.656512, 49.411047], [8.658857, 49.410217], [8.662864, 49.408734], [8.662656,
@@ -1657,7 +1657,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1750,7 +1750,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -1811,7 +1811,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -3559,7 +3559,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":
@@ -3620,7 +3620,7 @@ interactions:
     method: POST
     uri: http://testserver/report
   response:
-    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/data/COPYRIGHTS.md",
+    content: '{"apiVersion": "0.14.0", "attribution": {"url": "https://github.com/GIScience/ohsome-quality-analyst/blob/main/COPYRIGHTS.md",
       "text": "\u00a9 OpenStreetMap contributors"}, "type": "Feature", "id": 0, "geometry":
       {"type": "Polygon", "coordinates": [[[8.674092, 49.404271], [8.69585, 49.404271],
       [8.69585, 49.415552], [8.674092, 49.415552], [8.674092, 49.404271]]]}, "properties":

--- a/workers/tests/unittests/test_api.py
+++ b/workers/tests/unittests/test_api.py
@@ -16,7 +16,7 @@ class TestApi(unittest.TestCase):
             "attribution": {
                 "url": (
                     "https://github.com/GIScience/ohsome-quality-analyst/blob/main/"
-                    + "data/COPYRIGHTS.md"
+                    + "COPYRIGHTS.md"
                 ),
             },
         }


### PR DESCRIPTION
### Description
attribution URL was wrong and was replaced in this PR

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)