### PR TITLE
Add remaining metadata endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 - add plot creation via plotly to `MappingSaturation` indicator ([#499])
 - api: add `/metadata/topic` endpoint ([#519])
 - api: add `/metadata/indicators` endpoint ([#533])
+- api: add `/metadata/reports` endpoint ([#545])
+- api: add `/metadata` endpoint ([#545])
 
 ### Other Changes
 
@@ -90,6 +92,7 @@
 [#536]: https://github.com/GIScience/ohsome-quality-analyst/pull/536
 [#540]: https://github.com/GIScience/ohsome-quality-analyst/issues/540
 [#543]: https://github.com/GIScience/ohsome-quality-analyst/pull/543
+[#545]: https://github.com/GIScience/ohsome-quality-analyst/pull/545
 
 ## 0.14.2
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -33,13 +33,10 @@ from ohsome_quality_analyst.api.request_models import (
     TopicEnum,
 )
 from ohsome_quality_analyst.api.response_models import (
-    AllIndicatorMetadataResponse,
-    AllReportMetadataResponse,
-    AllTopicsResponse,
     IndicatorMetadataResponse,
     MetadataResponse,
     ReportMetadataResponse,
-    TopicResponse,
+    TopicMetadataResponse,
 )
 from ohsome_quality_analyst.config import configure_logging
 from ohsome_quality_analyst.definitions import (
@@ -376,21 +373,21 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
         "result": {k.value: {"key": True} for k in TopicEnum},
     },
 )
-async def metadata_topic(project: ProjectEnum = DEFAULT_PROJECT) -> AllTopicsResponse:
+async def metadata_topic(
+    project: ProjectEnum = DEFAULT_PROJECT,
+) -> TopicMetadataResponse:
     """Get topics."""
-    return AllTopicsResponse(result=get_topic_definitions(project=project.value))
+    return TopicMetadataResponse(result=get_topic_definitions(project=project.value))
 
 
 @app.get(
     "/metadata/topics/{key}",
     tags=["metadata"],
-    response_model_exclude={
-        "result": {"key": True},
-    },
+    response_model_exclude={"result": {k.value: {"key": True} for k in TopicEnum}},
 )
-async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
+async def metadata_topic_by_key(key: TopicEnum) -> TopicMetadataResponse:
     """Get topic by key."""
-    return TopicResponse(result=get_topic_definition(key.value))
+    return TopicMetadataResponse(result={key.value: get_topic_definition(key.value)})
 
 
 @app.get(
@@ -405,9 +402,9 @@ async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
 )
 async def metadata_indicators(
     project: ProjectEnum = DEFAULT_PROJECT,
-) -> AllIndicatorMetadataResponse:
+) -> IndicatorMetadataResponse:
     """Get metadata of all indicators."""
-    return AllIndicatorMetadataResponse(
+    return IndicatorMetadataResponse(
         result=get_indicator_definitions(project=project.value)
     )
 
@@ -416,13 +413,16 @@ async def metadata_indicators(
     "/metadata/indicators/{key}",
     tags=["metadata"],
     response_model_exclude={
-        "result": {"label_description": True, "result_description": True}
+        "result": {
+            k.value: {"label_description": True, "result_description": True}
+            for k in IndicatorEnum
+        }
     },
 )
 async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataResponse:
     """Get metadata of an indicator by key."""
     return IndicatorMetadataResponse(
-        result=get_metadata("indicators", hyphen_to_camel(key.value))
+        result={key.value: get_metadata("indicators", hyphen_to_camel(key.value))}
     )
 
 
@@ -435,22 +435,22 @@ async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataRes
 )
 async def metadata_reports(
     project: ProjectEnum = DEFAULT_PROJECT,
-) -> AllReportMetadataResponse:
+) -> ReportMetadataResponse:
     """Get metadata of all indicators."""
-    return AllReportMetadataResponse(
-        result=get_report_definitions(project=project.value)
-    )
+    return ReportMetadataResponse(result=get_report_definitions(project=project.value))
 
 
 @app.get(
     "/metadata/reports/{key}",
     tags=["metadata"],
-    response_model_exclude={"result": {"label_description": True}},
+    response_model_exclude={
+        "result": {k.value: {"label_description": True} for k in ReportEnum}
+    },
 )
 async def metadata_reports_by_key(key: ReportEnum) -> ReportMetadataResponse:
     """Get metadata of an indicator by key."""
     return ReportMetadataResponse(
-        result=get_metadata("reports", hyphen_to_camel(key.value))
+        result={key.value: get_metadata("reports", hyphen_to_camel(key.value))}
     )
 
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -26,6 +26,7 @@ from ohsome_quality_analyst.api.request_models import (
     IndicatorData,
     IndicatorDatabase,
     IndicatorEnum,
+    ProjectEnum,
     ReportBpolys,
     ReportDatabase,
     ReportEnum,
@@ -50,8 +51,8 @@ from ohsome_quality_analyst.definitions import (
     get_metadata,
     get_report_names,
     get_topic_definition,
+    get_topic_definitions,
     load_metadata,
-    load_topic_definitions,
 )
 from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.utils.exceptions import (
@@ -109,6 +110,9 @@ TAGS_METADATA = [
         },
     },
 ]
+
+# TODO: to be replaced by config
+DEFAULT_PROJECT = ProjectEnum.core
 
 configure_logging()
 logging.info("Logging enabled")
@@ -352,10 +356,10 @@ async def list_fid_fields():
         }
     },
 )
-async def metadata() -> MetadataResponse:
+async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
     """Get topics."""
     result = {
-        "topics": list(load_topic_definitions().values()),
+        "topics": get_topic_definitions(project=project.value),
         "indicators": list(load_metadata("indicators").values()),
         "reports": list(load_metadata("reports").values()),
     }
@@ -363,9 +367,9 @@ async def metadata() -> MetadataResponse:
 
 
 @app.get("/metadata/topics", tags=["metadata"])
-async def metadata_topic() -> TopicListResponse:
+async def metadata_topic(project: ProjectEnum = DEFAULT_PROJECT) -> TopicListResponse:
     """Get topics."""
-    return TopicListResponse(result=list(load_topic_definitions().values()))
+    return TopicListResponse(result=get_topic_definitions(project=project.value))
 
 
 @app.get("/metadata/topics/{key}", tags=["metadata"])

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -28,12 +28,15 @@ from ohsome_quality_analyst.api.request_models import (
     IndicatorEnum,
     ReportBpolys,
     ReportDatabase,
+    ReportEnum,
     TopicEnum,
 )
 from ohsome_quality_analyst.api.response_models import (
     IndicatorMetadataListResponse,
     IndicatorMetadataResponse,
     MetadataResponse,
+    ReportMetadataListResponse,
+    ReportMetadataResponse,
     TopicListResponse,
     TopicResponse,
 )
@@ -345,6 +348,7 @@ async def list_fid_fields():
             "indicators": {
                 "__all__": {"label_description": True, "result_description": True}
             },
+            "reports": {"__all__": {"label_description": True}},
         }
     },
 )
@@ -353,6 +357,7 @@ async def metadata() -> MetadataResponse:
     result = {
         "topics": list(load_topic_definitions().values()),
         "indicators": list(load_metadata("indicators").values()),
+        "reports": list(load_metadata("reports").values()),
     }
     return MetadataResponse(result=result)
 
@@ -394,6 +399,28 @@ async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataRes
     """Get metadata of an indicator by key."""
     return IndicatorMetadataResponse(
         result=get_metadata("indicators", hyphen_to_camel(key.value))
+    )
+
+
+@app.get(
+    "/metadata/reports",
+    tags=["metadata"],
+    response_model_exclude={"result": {"__all__": {"label_description": True}}},
+)
+async def metadata_reports() -> ReportMetadataListResponse:
+    """Get metadata of all indicators."""
+    return ReportMetadataListResponse(result=list(load_metadata("reports").values()))
+
+
+@app.get(
+    "/metadata/reports/{key}",
+    tags=["metadata"],
+    response_model_exclude={"result": {"label_description": True}},
+)
+async def metadata_reports_by_key(key: ReportEnum) -> ReportMetadataResponse:
+    """Get metadata of an indicator by key."""
+    return ReportMetadataResponse(
+        result=get_metadata("reports", hyphen_to_camel(key.value))
     )
 
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -47,6 +47,7 @@ from ohsome_quality_analyst.definitions import (
     get_attribution,
     get_dataset_names,
     get_fid_fields,
+    get_indicator_definitions,
     get_indicator_names,
     get_metadata,
     get_report_names,
@@ -360,7 +361,7 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
     """Get topics."""
     result = {
         "topics": get_topic_definitions(project=project.value),
-        "indicators": list(load_metadata("indicators").values()),
+        "indicators": get_indicator_definitions(project=project.value),
         "reports": list(load_metadata("reports").values()),
     }
     return MetadataResponse(result=result)
@@ -385,10 +386,12 @@ async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
         "result": {"__all__": {"label_description": True, "result_description": True}}
     },
 )
-async def metadata_indicators() -> IndicatorMetadataListResponse:
+async def metadata_indicators(
+    project: ProjectEnum = DEFAULT_PROJECT,
+) -> IndicatorMetadataListResponse:
     """Get metadata of all indicators."""
     return IndicatorMetadataListResponse(
-        result=list(load_metadata("indicators").values())
+        result=get_indicator_definitions(project=project.value)
     )
 
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -50,10 +50,10 @@ from ohsome_quality_analyst.definitions import (
     get_indicator_definitions,
     get_indicator_names,
     get_metadata,
+    get_report_definitions,
     get_report_names,
     get_topic_definition,
     get_topic_definitions,
-    load_metadata,
 )
 from ohsome_quality_analyst.geodatabase import client as db_client
 from ohsome_quality_analyst.utils.exceptions import (
@@ -362,7 +362,7 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
     result = {
         "topics": get_topic_definitions(project=project.value),
         "indicators": get_indicator_definitions(project=project.value),
-        "reports": list(load_metadata("reports").values()),
+        "reports": get_report_definitions(project=project.value),
     }
     return MetadataResponse(result=result)
 
@@ -414,9 +414,13 @@ async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataRes
     tags=["metadata"],
     response_model_exclude={"result": {"__all__": {"label_description": True}}},
 )
-async def metadata_reports() -> ReportMetadataListResponse:
+async def metadata_reports(
+    project: ProjectEnum = DEFAULT_PROJECT,
+) -> ReportMetadataListResponse:
     """Get metadata of all indicators."""
-    return ReportMetadataListResponse(result=list(load_metadata("reports").values()))
+    return ReportMetadataListResponse(
+        result=get_report_definitions(project=project.value)
+    )
 
 
 @app.get(

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -33,12 +33,12 @@ from ohsome_quality_analyst.api.request_models import (
     TopicEnum,
 )
 from ohsome_quality_analyst.api.response_models import (
-    IndicatorMetadataListResponse,
+    AllIndicatorMetadataResponse,
+    AllReportMetadataResponse,
+    AllTopicsResponse,
     IndicatorMetadataResponse,
     MetadataResponse,
-    ReportMetadataListResponse,
     ReportMetadataResponse,
-    TopicListResponse,
     TopicResponse,
 )
 from ohsome_quality_analyst.config import configure_logging
@@ -376,9 +376,9 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
         "result": {k.value: {"key": True} for k in TopicEnum},
     },
 )
-async def metadata_topic(project: ProjectEnum = DEFAULT_PROJECT) -> TopicListResponse:
+async def metadata_topic(project: ProjectEnum = DEFAULT_PROJECT) -> AllTopicsResponse:
     """Get topics."""
-    return TopicListResponse(result=get_topic_definitions(project=project.value))
+    return AllTopicsResponse(result=get_topic_definitions(project=project.value))
 
 
 @app.get(
@@ -405,9 +405,9 @@ async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
 )
 async def metadata_indicators(
     project: ProjectEnum = DEFAULT_PROJECT,
-) -> IndicatorMetadataListResponse:
+) -> AllIndicatorMetadataResponse:
     """Get metadata of all indicators."""
-    return IndicatorMetadataListResponse(
+    return AllIndicatorMetadataResponse(
         result=get_indicator_definitions(project=project.value)
     )
 
@@ -435,9 +435,9 @@ async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataRes
 )
 async def metadata_reports(
     project: ProjectEnum = DEFAULT_PROJECT,
-) -> ReportMetadataListResponse:
+) -> AllReportMetadataResponse:
     """Get metadata of all indicators."""
-    return ReportMetadataListResponse(
+    return AllReportMetadataResponse(
         result=get_report_definitions(project=project.value)
     )
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -350,6 +350,7 @@ async def list_fid_fields():
     tags=["metadata"],
     response_model_exclude={
         "result": {
+            "topics": {k.value: {"key": True} for k in TopicEnum},
             "indicators": {
                 k.value: {"label_description": True, "result_description": True}
                 for k in IndicatorEnum
@@ -368,13 +369,25 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
     return MetadataResponse(result=result)
 
 
-@app.get("/metadata/topics", tags=["metadata"])
+@app.get(
+    "/metadata/topics",
+    tags=["metadata"],
+    response_model_exclude={
+        "result": {k.value: {"key": True} for k in TopicEnum},
+    },
+)
 async def metadata_topic(project: ProjectEnum = DEFAULT_PROJECT) -> TopicListResponse:
     """Get topics."""
     return TopicListResponse(result=get_topic_definitions(project=project.value))
 
 
-@app.get("/metadata/topics/{key}", tags=["metadata"])
+@app.get(
+    "/metadata/topics/{key}",
+    tags=["metadata"],
+    response_model_exclude={
+        "result": {"key": True},
+    },
+)
 async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
     """Get topic by key."""
     return TopicResponse(result=get_topic_definition(key.value))

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -351,9 +351,10 @@ async def list_fid_fields():
     response_model_exclude={
         "result": {
             "indicators": {
-                "__all__": {"label_description": True, "result_description": True}
+                k.value: {"label_description": True, "result_description": True}
+                for k in IndicatorEnum
             },
-            "reports": {"__all__": {"label_description": True}},
+            "reports": {k.value: {"label_description": True} for k in ReportEnum},
         }
     },
 )
@@ -383,7 +384,10 @@ async def metadata_topic_by_key(key: TopicEnum) -> TopicResponse:
     "/metadata/indicators",
     tags=["metadata"],
     response_model_exclude={
-        "result": {"__all__": {"label_description": True, "result_description": True}}
+        "result": {
+            k.value: {"label_description": True, "result_description": True}
+            for k in IndicatorEnum
+        },
     },
 )
 async def metadata_indicators(
@@ -412,7 +416,9 @@ async def metadata_indicators_by_key(key: IndicatorEnum) -> IndicatorMetadataRes
 @app.get(
     "/metadata/reports",
     tags=["metadata"],
-    response_model_exclude={"result": {"__all__": {"label_description": True}}},
+    response_model_exclude={
+        "result": {k.value: {"label_description": True} for k in ReportEnum}
+    },
 )
 async def metadata_reports(
     project: ProjectEnum = DEFAULT_PROJECT,

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -33,6 +33,7 @@ from ohsome_quality_analyst.api.request_models import (
 from ohsome_quality_analyst.api.response_models import (
     IndicatorMetadataListResponse,
     IndicatorMetadataResponse,
+    MetadataResponse,
     TopicListResponse,
     TopicResponse,
 )
@@ -334,6 +335,26 @@ async def list_fid_fields():
     response = empty_api_response()
     response["result"] = get_fid_fields()
     return response
+
+
+@app.get(
+    "/metadata",
+    tags=["metadata"],
+    response_model_exclude={
+        "result": {
+            "indicators": {
+                "__all__": {"label_description": True, "result_description": True}
+            },
+        }
+    },
+)
+async def metadata() -> MetadataResponse:
+    """Get topics."""
+    result = {
+        "topics": list(load_topic_definitions().values()),
+        "indicators": list(load_metadata("indicators").values()),
+    }
+    return MetadataResponse(result=result)
 
 
 @app.get("/metadata/topics", tags=["metadata"])

--- a/workers/ohsome_quality_analyst/api/request_models.py
+++ b/workers/ohsome_quality_analyst/api/request_models.py
@@ -18,6 +18,7 @@ from ohsome_quality_analyst.definitions import (
     get_dataset_names,
     get_fid_fields,
     get_indicator_names,
+    get_project_keys,
     get_report_names,
     get_topic_keys,
     get_valid_indicators,
@@ -30,6 +31,7 @@ ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})
 TopicEnum = Enum("TopicEnum", {name: name for name in get_topic_keys()})
 DatasetEnum = Enum("DatasetNames", {name: name for name in get_dataset_names()})
 FidFieldEnum = Enum("FidFieldEnum", {name: name for name in get_fid_fields()})
+ProjectEnum = Enum("ProjectEnum", {name: name for name in get_project_keys()})
 
 
 class BaseIndicator(BaseModel):

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from ohsome_quality_analyst import __version__
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
+from ohsome_quality_analyst.reports.models import ReportMetadata
 from ohsome_quality_analyst.topics.models import TopicDefinition
 from ohsome_quality_analyst.utils.helper import snake_to_hyphen
 
@@ -33,9 +34,18 @@ class IndicatorMetadataListResponse(ResponseBase):
     result: list[IndicatorMetadata]
 
 
+class ReportMetadataResponse(ResponseBase):
+    result: ReportMetadata
+
+
+class ReportMetadataListResponse(ResponseBase):
+    result: list[ReportMetadata]
+
+
 class MetadataResponse(ResponseBase):
     class MetadataResultSchema(BaseModel):
         indicators: list[IndicatorMetadata]
+        reports: list[ReportMetadata]
         topics: list[TopicDefinition]
 
     result: MetadataResultSchema

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -23,7 +23,7 @@ class TopicResponse(ResponseBase):
 
 
 class TopicListResponse(ResponseBase):
-    result: list[TopicDefinition]
+    result: dict[str, TopicDefinition]
 
 
 class IndicatorMetadataResponse(ResponseBase):
@@ -31,7 +31,7 @@ class IndicatorMetadataResponse(ResponseBase):
 
 
 class IndicatorMetadataListResponse(ResponseBase):
-    result: list[IndicatorMetadata]
+    result: dict[str, IndicatorMetadata]
 
 
 class ReportMetadataResponse(ResponseBase):
@@ -39,13 +39,13 @@ class ReportMetadataResponse(ResponseBase):
 
 
 class ReportMetadataListResponse(ResponseBase):
-    result: list[ReportMetadata]
+    result: dict[str, ReportMetadata]
 
 
 class MetadataResponse(ResponseBase):
     class MetadataResultSchema(BaseModel):
-        indicators: list[IndicatorMetadata]
-        reports: list[ReportMetadata]
-        topics: list[TopicDefinition]
+        indicators: dict[str, IndicatorMetadata]
+        reports: dict[str, ReportMetadata]
+        topics: dict[str, TopicDefinition]
 
     result: MetadataResultSchema

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -1,6 +1,11 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from ohsome_quality_analyst import __version__
+from ohsome_quality_analyst.api.request_models import (
+    IndicatorEnum,
+    ReportEnum,
+    TopicEnum,
+)
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.reports.models import ReportMetadata
@@ -21,13 +26,37 @@ class ResponseBase(BaseModel):
 class TopicMetadataResponse(ResponseBase):
     result: dict[str, TopicDefinition]
 
+    @validator("result")
+    @classmethod
+    def check_topic_dict(cls, value):
+        assert len(value) > 0
+        for key in value.keys():
+            TopicEnum(key)
+        return value
+
 
 class IndicatorMetadataResponse(ResponseBase):
     result: dict[str, IndicatorMetadata]
 
+    @validator("result")
+    @classmethod
+    def check_indicator_dict(cls, value):
+        assert len(value) > 0
+        for key in value.keys():
+            IndicatorEnum(key)
+        return value
+
 
 class ReportMetadataResponse(ResponseBase):
     result: dict[str, ReportMetadata]
+
+    @validator("result")
+    @classmethod
+    def check_report_dict(cls, value):
+        assert len(value) > 0
+        for key in value.keys():
+            ReportEnum(key)
+        return value
 
 
 class MetadataResponse(ResponseBase):

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -22,7 +22,7 @@ class TopicResponse(ResponseBase):
     result: TopicDefinition
 
 
-class TopicListResponse(ResponseBase):
+class AllTopicsResponse(ResponseBase):
     result: dict[str, TopicDefinition]
 
 
@@ -30,7 +30,7 @@ class IndicatorMetadataResponse(ResponseBase):
     result: IndicatorMetadata
 
 
-class IndicatorMetadataListResponse(ResponseBase):
+class AllIndicatorMetadataResponse(ResponseBase):
     result: dict[str, IndicatorMetadata]
 
 
@@ -38,7 +38,7 @@ class ReportMetadataResponse(ResponseBase):
     result: ReportMetadata
 
 
-class ReportMetadataListResponse(ResponseBase):
+class AllReportMetadataResponse(ResponseBase):
     result: dict[str, ReportMetadata]
 
 

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -31,3 +31,11 @@ class IndicatorMetadataResponse(ResponseBase):
 
 class IndicatorMetadataListResponse(ResponseBase):
     result: list[IndicatorMetadata]
+
+
+class MetadataResponse(ResponseBase):
+    class MetadataResultSchema(BaseModel):
+        indicators: list[IndicatorMetadata]
+        topics: list[TopicDefinition]
+
+    result: MetadataResultSchema

--- a/workers/ohsome_quality_analyst/api/response_models.py
+++ b/workers/ohsome_quality_analyst/api/response_models.py
@@ -18,27 +18,15 @@ class ResponseBase(BaseModel):
         extra = "forbid"
 
 
-class TopicResponse(ResponseBase):
-    result: TopicDefinition
-
-
-class AllTopicsResponse(ResponseBase):
+class TopicMetadataResponse(ResponseBase):
     result: dict[str, TopicDefinition]
 
 
 class IndicatorMetadataResponse(ResponseBase):
-    result: IndicatorMetadata
-
-
-class AllIndicatorMetadataResponse(ResponseBase):
     result: dict[str, IndicatorMetadata]
 
 
 class ReportMetadataResponse(ResponseBase):
-    result: ReportMetadata
-
-
-class AllReportMetadataResponse(ResponseBase):
     result: dict[str, ReportMetadata]
 
 

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -147,7 +147,7 @@ def load_topic_definitions() -> dict[str, TopicDefinition]:
 
 def get_topic_definitions(project: str = None) -> dict[str, TopicDefinition]:
     topics = load_topic_definitions()
-    if project:
+    if project is not None:
         return {k: v for k, v in topics.items() if v.project == project}
     else:
         return topics
@@ -155,7 +155,7 @@ def get_topic_definitions(project: str = None) -> dict[str, TopicDefinition]:
 
 def get_indicator_definitions(project: str = None) -> dict[str, IndicatorMetadata]:
     indicators = load_metadata("indicators")
-    if project:
+    if project is not None:
         return {k: v for k, v in indicators.items() if v.project == project}
     else:
         return indicators
@@ -163,7 +163,7 @@ def get_indicator_definitions(project: str = None) -> dict[str, IndicatorMetadat
 
 def get_report_definitions(project: str = None) -> dict[str, ReportMetadata]:
     reports = load_metadata("reports")
-    if project:
+    if project is not None:
         return {k: v for k, v in reports.items() if v.project == project}
     else:
         return reports

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -148,9 +148,17 @@ def load_topic_definitions() -> dict[str, TopicDefinition]:
 def get_topic_definitions(project: str = None) -> list[TopicDefinition]:
     topics = load_topic_definitions()
     if project:
-        return [v for v in topics.values() if v.project == project.value]
+        return [v for v in topics.values() if v.project == project]
     else:
         return list(topics.values())
+
+
+def get_indicator_definitions(project: str = None) -> list[IndicatorMetadata]:
+    indicators = load_metadata("indicators")
+    if project:
+        return [v for v in indicators.values() if v.project == project]
+    else:
+        return list(indicators.values())
 
 
 def get_topic_definition(topic_key: str) -> TopicDefinition:

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -4,7 +4,7 @@ import logging
 import os
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal
+from typing import Iterable, Literal
 
 import yaml
 
@@ -145,6 +145,14 @@ def load_topic_definitions() -> dict[str, TopicDefinition]:
     return topics
 
 
+def get_topic_definitions(project: str = None) -> list[TopicDefinition]:
+    topics = load_topic_definitions()
+    if project:
+        return [v for v in topics.values() if v.project == project.value]
+    else:
+        return list(topics.values())
+
+
 def get_topic_definition(topic_key: str) -> TopicDefinition:
     """Get ohsome API parameters of a single topic based on topic key."""
     topics = load_topic_definitions()
@@ -182,6 +190,10 @@ def get_report_names() -> list[str]:
 
 def get_topic_keys() -> list[str]:
     return [str(t) for t in load_topic_definitions().keys()]
+
+
+def get_project_keys() -> Iterable[str]:
+    return set(t.project for t in load_topic_definitions().values())
 
 
 def get_dataset_names() -> list[str]:

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -78,7 +78,7 @@ ATTRIBUTION_URL = (
 
 def load_metadata(
     module_name: Literal["indicators", "reports"]
-) -> dict[str, IndicatorMetadata, ReportMetadata]:
+) -> dict[str, IndicatorMetadata | ReportMetadata]:
     """Read metadata of all indicators or reports from YAML files.
 
     Those text files are located in the directory of each indicator/report.
@@ -145,28 +145,28 @@ def load_topic_definitions() -> dict[str, TopicDefinition]:
     return topics
 
 
-def get_topic_definitions(project: str = None) -> list[TopicDefinition]:
+def get_topic_definitions(project: str = None) -> dict[str, TopicDefinition]:
     topics = load_topic_definitions()
     if project:
-        return [v for v in topics.values() if v.project == project]
+        return {k: v for k, v in topics.items() if v.project == project}
     else:
-        return list(topics.values())
+        return topics
 
 
-def get_indicator_definitions(project: str = None) -> list[IndicatorMetadata]:
+def get_indicator_definitions(project: str = None) -> dict[str, IndicatorMetadata]:
     indicators = load_metadata("indicators")
     if project:
-        return [v for v in indicators.values() if v.project == project]
+        return {k: v for k, v in indicators.items() if v.project == project}
     else:
-        return list(indicators.values())
+        return indicators
 
 
-def get_report_definitions(project: str = None) -> list[ReportMetadata]:
+def get_report_definitions(project: str = None) -> dict[str, ReportMetadata]:
     reports = load_metadata("reports")
     if project:
-        return [v for v in reports.values() if v.project == project]
+        return {k: v for k, v in reports.items() if v.project == project}
     else:
-        return list(reports.values())
+        return reports
 
 
 def get_topic_definition(topic_key: str) -> TopicDefinition:

--- a/workers/ohsome_quality_analyst/definitions.py
+++ b/workers/ohsome_quality_analyst/definitions.py
@@ -161,6 +161,14 @@ def get_indicator_definitions(project: str = None) -> list[IndicatorMetadata]:
         return list(indicators.values())
 
 
+def get_report_definitions(project: str = None) -> list[ReportMetadata]:
+    reports = load_metadata("reports")
+    if project:
+        return [v for v in reports.values() if v.project == project]
+    else:
+        return list(reports.values())
+
+
 def get_topic_definition(topic_key: str) -> TopicDefinition:
     """Get ohsome API parameters of a single topic based on topic key."""
     topics = load_topic_definitions()

--- a/workers/ohsome_quality_analyst/indicators/attribute_completeness/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/attribute_completeness/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 attribute-completeness:
   name: Attribute Completeness
+  project: experimental
   description: >-
       Derive the ratio of OSM features compared to features which
       match additional expected tags (e.g. amenity=hospital vs

--- a/workers/ohsome_quality_analyst/indicators/building_completeness/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/building_completeness/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 building-completeness:
   name: Building Completeness
+  project: experimental
   description: >-
     Weighted average of the ratio between predicted building area and the actual building area in OSM.
     This can give an estimate if mapping has been completed.

--- a/workers/ohsome_quality_analyst/indicators/currentness/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/currentness/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 currentness:
   name: Currentness
+  project: experimental
   description: >-
     Ratio of all contributions that have been edited since 2008 until the current day in relation with years without mapping activities in the same
     time range. 

--- a/workers/ohsome_quality_analyst/indicators/mapping_saturation/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/mapping_saturation/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 mapping-saturation:
   name: Mapping Saturation
+  project: core
   description: >-
     Calculate if mapping has saturated.
     High saturation has been reached if the growth of the fitted curve is minimal.

--- a/workers/ohsome_quality_analyst/indicators/minimal/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/minimal/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 minimal:
   name: Minimal
+  project: misc
   description: >-
       An minimal Indicator for testing purposes.
   label-description:

--- a/workers/ohsome_quality_analyst/indicators/models.py
+++ b/workers/ohsome_quality_analyst/indicators/models.py
@@ -13,6 +13,7 @@ class IndicatorMetadata(BaseModel):
     description: str
     label_description: dict
     result_description: str
+    project: str
 
     class Config:
         alias_generator = snake_to_hyphen

--- a/workers/ohsome_quality_analyst/indicators/poi_density/metadata.yaml
+++ b/workers/ohsome_quality_analyst/indicators/poi_density/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 poi-density:
   name: POI Density
+  project: experimental
   description: >-
       The density of Point of Interests (POI).
       It is calculated by the number of features 

--- a/workers/ohsome_quality_analyst/reports/building_report/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/building_report/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 building-report:
   name: Building Report
+  project: experimental
   description: >-
       This report gives a general overview of the quality for buildings.
   label-description:

--- a/workers/ohsome_quality_analyst/reports/food_related_report/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/food_related_report/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 food-related-report:
   name: Food Related Report
+  project: experimental
   description: >-
     This report shows the quality of food related POIs. 
     If one indicator shows bad quality or is undefined this report also shows bad quality or is undefined respectively.

--- a/workers/ohsome_quality_analyst/reports/map_action_poc/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/map_action_poc/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 map-action-poc:
   name: MapAction POC Country Overview
+  project: experimental
   description: >-
     This report is a proof of concept (POC) data quality report for a MapAction country overview product.
   label-description:

--- a/workers/ohsome_quality_analyst/reports/minimal/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/minimal/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 minimal:
   name: Minimal
+  project: misc
   description: >-
     This report shows the quality for two indicators:
     Mapping Saturation and Currentness.

--- a/workers/ohsome_quality_analyst/reports/models.py
+++ b/workers/ohsome_quality_analyst/reports/models.py
@@ -11,6 +11,7 @@ class ReportMetadata(BaseModel):
     name: str
     description: str
     label_description: dict
+    project: str
 
     class Config:
         alias_generator = snake_to_hyphen

--- a/workers/ohsome_quality_analyst/reports/multilevel_currentness/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/multilevel_currentness/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 multilevel-currentness:
   name: Multilevel Currentness
+  project: experimental
   description: >-
     This report shows the currentness of four major map features (https://wiki.openstreetmap.org/wiki/Map_features):
     buildings, land-use and land-cover, points of interest and infrastructure.

--- a/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/metadata.yaml
@@ -1,6 +1,6 @@
 multilevel-mapping-saturation:
   name: Multilevel Mapping Saturation
-  project: experimental
+  project: core
   description: >-
     This report shows the mapping saturation of four major Map Features (https://wiki.openstreetmap.org/wiki/Map_features): buildings, land-use/land-cover, points of interest and infrastructure.
     It evolved from the OSM Element Vectorisation tool (https://gitlab.gistools.geog.uni-heidelberg.de/giscience/ideal-vgi/osm-element-vectorisation).

--- a/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/multilevel_mapping_saturation/metadata.yaml
@@ -1,5 +1,6 @@
 multilevel-mapping-saturation:
   name: Multilevel Mapping Saturation
+  project: experimental
   description: >-
     This report shows the mapping saturation of four major Map Features (https://wiki.openstreetmap.org/wiki/Map_features): buildings, land-use/land-cover, points of interest and infrastructure.
     It evolved from the OSM Element Vectorisation tool (https://gitlab.gistools.geog.uni-heidelberg.de/giscience/ideal-vgi/osm-element-vectorisation).

--- a/workers/ohsome_quality_analyst/reports/road_report/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/road_report/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 road-report:
   name: Road Report
+  project: experimental
   description: >-
     This report gives a general overview of the quality for roads.
   label-description:

--- a/workers/ohsome_quality_analyst/reports/sketchmap_fitness/metadata.yaml
+++ b/workers/ohsome_quality_analyst/reports/sketchmap_fitness/metadata.yaml
@@ -1,6 +1,7 @@
 ---
 sketchmap-fitness:
   name: Sketch Map Fitness
+  project: sketchmap
   description: >-
     The Sketch Map Fitness Report consists of four data quality indicators
     (mapping saturation of major roads, currentness of major roads and

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -35,8 +35,8 @@ def topics_dict() -> dict[str, TopicDefinition]:
 
 
 @pytest.fixture()
-def topics_list(topics_dict) -> list[TopicDefinition]:
-    return list(topics_dict.values())
+def topics_list(topics_dict) -> dict[str, TopicDefinition]:
+    return topics_dict
 
 
 @pytest.fixture(scope="class")
@@ -65,5 +65,5 @@ def indicator_metadata_minimal() -> IndicatorMetadata:
 
 
 @pytest.fixture
-def indicators_metadata() -> list[IndicatorMetadata]:
-    return list(load_metadata("indicators").values())
+def indicators_metadata() -> dict[str, IndicatorMetadata]:
+    return load_metadata("indicators")

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -30,13 +30,8 @@ def topic_building_count(topic_key_building_count) -> TopicDefinition:
 
 
 @pytest.fixture()
-def topics_dict() -> dict[str, TopicDefinition]:
+def topic_definitions() -> dict[str, TopicDefinition]:
     return load_topic_definitions()
-
-
-@pytest.fixture()
-def topics_list(topics_dict) -> dict[str, TopicDefinition]:
-    return topics_dict
 
 
 @pytest.fixture(scope="class")

--- a/workers/tests/conftest.py
+++ b/workers/tests/conftest.py
@@ -11,6 +11,7 @@ from ohsome_quality_analyst.definitions import (
     load_topic_definitions,
 )
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
+from ohsome_quality_analyst.reports.models import ReportMetadata
 
 # from ohsome_quality_analyst.indicators import MappingSaturation
 # from ohsome_quality_analyst.indicators.models import BaseIndicator as Indicator
@@ -27,6 +28,14 @@ def topic_key_building_count() -> str:
 @pytest.fixture(scope="class")
 def topic_building_count(topic_key_building_count) -> TopicDefinition:
     return get_topic_definition(topic_key_building_count)
+
+
+@pytest.fixture(scope="class")
+def metadata_topic_building_count(
+    topic_key_building_count,
+    topic_building_count,
+) -> dict[str, TopicDefinition]:
+    return {topic_key_building_count: topic_building_count}
 
 
 @pytest.fixture()
@@ -55,10 +64,20 @@ def feature_collection_germany_heidelberg_bahnstadt_bergheim() -> FeatureCollect
 
 
 @pytest.fixture
-def indicator_metadata_minimal() -> IndicatorMetadata:
-    return get_metadata("indicators", "Minimal")
+def metadata_indicator_minimal() -> dict[str, IndicatorMetadata]:
+    return {"minimal": get_metadata("indicators", "Minimal")}
 
 
 @pytest.fixture
 def indicators_metadata() -> dict[str, IndicatorMetadata]:
     return load_metadata("indicators")
+
+
+@pytest.fixture
+def metadata_report_minimal() -> dict[str, ReportMetadata]:
+    return {"minimal": get_metadata("reports", "Minimal")}
+
+
+@pytest.fixture
+def reports_metadata() -> dict[str, ReportMetadata]:
+    return load_metadata("reports")

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -51,6 +51,7 @@ def metadata_mapping_saturation():
             "Calculate if mapping has saturated. High saturation has been reached if "
             + "the growth of the fitted curve is minimal."
         ),
+        "project": "core",
     }
 
 
@@ -74,6 +75,7 @@ def metadata_indicator_minimal():
     return {
         "name": "Minimal",
         "description": "An minimal Indicator for testing purposes.",
+        "project": "misc",
     }
 
 

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -75,3 +75,15 @@ def metadata_indicator_minimal():
         "name": "Minimal",
         "description": "An minimal Indicator for testing purposes.",
     }
+
+
+@pytest.fixture
+def metadata_report_minimal():
+    return {
+        "name": "Minimal",
+        "description": (
+            "This report shows the quality for two indicators: Mapping Saturation and "
+            + "Currentness. It's main function is to test the interactions between "
+            + "database, api and website."
+        ),
+    }

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -88,4 +88,5 @@ def metadata_report_minimal():
             + "Currentness. It's main function is to test the interactions between "
             + "database, api and website."
         ),
+        "project": "misc",
     }

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -26,7 +26,6 @@ def response_template():
 @pytest.fixture
 def building_count():
     return {
-        "key": "building_count",
         "name": "Building Count",
         "description": (
             "All buildings as defined by all objects tagged with 'building=*'."

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -26,66 +26,80 @@ def response_template():
 @pytest.fixture
 def metadata_topic_building_count():
     return {
-        "name": "Building Count",
-        "description": (
-            "All buildings as defined by all objects tagged with 'building=*'."
-        ),
-        "endpoint": "elements/count",
-        "filter": "building=* and building!=no and geometry:polygon",
-        "indicators": ["mapping-saturation", "currentness", "attribute-completeness"],
-        "ratio_filter": (
-            "building=* and building!=no and geometry:polygon and height=* or "
-            + "building:levels=*"
-        ),
-        "project": "core",
-        "source": None,  # TODO: Should not be in response if None
+        "building_count": {
+            "name": "Building Count",
+            "description": (
+                "All buildings as defined by all objects tagged with 'building=*'."
+            ),
+            "endpoint": "elements/count",
+            "filter": "building=* and building!=no and geometry:polygon",
+            "indicators": [
+                "mapping-saturation",
+                "currentness",
+                "attribute-completeness",
+            ],
+            "ratio_filter": (
+                "building=* and building!=no and geometry:polygon and height=* or "
+                + "building:levels=*"
+            ),
+            "project": "core",
+            "source": None,  # TODO: Should not be in response if None
+        }
     }
 
 
 @pytest.fixture
 def metadata_indicator_mapping_saturation():
     return {
-        "name": "Mapping Saturation",
-        "description": (
-            "Calculate if mapping has saturated. High saturation has been reached if "
-            + "the growth of the fitted curve is minimal."
-        ),
-        "project": "core",
+        "mapping-saturation": {
+            "name": "Mapping Saturation",
+            "description": (
+                "Calculate if mapping has saturated. High saturation has been reached "
+                + "if the growth of the fitted curve is minimal."
+            ),
+            "project": "core",
+        }
     }
 
 
 @pytest.fixture
 def metadata_topic_minimal():
     return {
-        "key": "minimal",
-        "name": "Minimal",
-        "description": "A minimal topic definition for testing purposes",
-        "endpoint": "elements/count",
-        "filter": "building=* and building!=no and geometry:polygon",
-        "indicators": ["minimal"],
-        "ratio_filter": None,  # TODO: Should not be in response if None
-        "project": "misc",
-        "source": None,  # TODO: Should not be in response if None
+        "minimal": {
+            "key": "minimal",
+            "name": "Minimal",
+            "description": "A minimal topic definition for testing purposes",
+            "endpoint": "elements/count",
+            "filter": "building=* and building!=no and geometry:polygon",
+            "indicators": ["minimal"],
+            "ratio_filter": None,  # TODO: Should not be in response if None
+            "project": "misc",
+            "source": None,  # TODO: Should not be in response if None
+        }
     }
 
 
 @pytest.fixture
 def metadata_indicator_minimal():
     return {
-        "name": "Minimal",
-        "description": "An minimal Indicator for testing purposes.",
-        "project": "misc",
+        "minimal": {
+            "name": "Minimal",
+            "description": "An minimal Indicator for testing purposes.",
+            "project": "misc",
+        }
     }
 
 
 @pytest.fixture
 def metadata_report_minimal():
     return {
-        "name": "Minimal",
-        "description": (
-            "This report shows the quality for two indicators: Mapping Saturation and "
-            + "Currentness. It's main function is to test the interactions between "
-            + "database, api and website."
-        ),
-        "project": "misc",
+        "minimal": {
+            "name": "Minimal",
+            "description": (
+                "This report shows the quality for two indicators: Mapping Saturation "
+                + "and Currentness. It's main function is to test the interactions "
+                + "between database, api and website."
+            ),
+            "project": "misc",
+        }
     }

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -21,3 +21,57 @@ def response_template():
             ),
         },
     }
+
+
+@pytest.fixture
+def building_count():
+    return {
+        "key": "building_count",
+        "name": "Building Count",
+        "description": (
+            "All buildings as defined by all objects tagged with 'building=*'."
+        ),
+        "endpoint": "elements/count",
+        "filter": "building=* and building!=no and geometry:polygon",
+        "indicators": ["mapping-saturation", "currentness", "attribute-completeness"],
+        "ratio_filter": (
+            "building=* and building!=no and geometry:polygon and height=* or "
+            + "building:levels=*"
+        ),
+        "project": "core",
+        "source": None,  # TODO: Should not be in response if None
+    }
+
+
+@pytest.fixture
+def metadata_mapping_saturation():
+    return {
+        "name": "Mapping Saturation",
+        "description": (
+            "Calculate if mapping has saturated. High saturation has been reached if "
+            + "the growth of the fitted curve is minimal."
+        ),
+    }
+
+
+@pytest.fixture
+def metadata_topic_minimal():
+    return {
+        "key": "minimal",
+        "name": "Minimal",
+        "description": "A minimal topic definition for testing purposes",
+        "endpoint": "elements/count",
+        "filter": "building=* and building!=no and geometry:polygon",
+        "indicators": ["minimal"],
+        "ratio_filter": None,  # TODO: Should not be in response if None
+        "project": "misc",
+        "source": None,  # TODO: Should not be in response if None
+    }
+
+
+@pytest.fixture
+def metadata_indicator_minimal():
+    return {
+        "name": "Minimal",
+        "description": "An minimal Indicator for testing purposes.",
+    }

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -24,7 +24,7 @@ def response_template():
 
 
 @pytest.fixture
-def building_count():
+def metadata_topic_building_count():
     return {
         "name": "Building Count",
         "description": (
@@ -43,7 +43,7 @@ def building_count():
 
 
 @pytest.fixture
-def metadata_mapping_saturation():
+def metadata_indicator_mapping_saturation():
     return {
         "name": "Mapping Saturation",
         "description": (

--- a/workers/tests/integrationtests/api/conftest.py
+++ b/workers/tests/integrationtests/api/conftest.py
@@ -63,6 +63,22 @@ def metadata_indicator_mapping_saturation():
 
 
 @pytest.fixture
+def metadata_report_multilevel_mapping_saturation():
+    return {
+        "multilevel-mapping-saturation": {
+            "name": "Multilevel Mapping Saturation",
+            "description": "This report shows the mapping saturation of four major "
+            + "Map Features (https://wiki.openstreetmap.org/wiki/Map_features): "
+            + "buildings, land-use/land-cover, points of interest and infrastructure. "
+            + "It evolved from the OSM Element Vectorisation tool (https://gitlab."
+            + "gistools.geog.uni-heidelberg.de/giscience/ideal-vgi/osm-element-"
+            + "vectorisation).",
+            "project": "core",
+        }
+    }
+
+
+@pytest.fixture
 def metadata_topic_minimal():
     return {
         "minimal": {

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -2,7 +2,11 @@ import pytest
 
 
 def test_metadata(
-    client, response_template, building_count, metadata_mapping_saturation
+    client,
+    response_template,
+    building_count,
+    metadata_mapping_saturation,
+    metadata_report_minimal,
 ):
     response = client.get("/metadata")
     assert response.status_code == 200
@@ -20,7 +24,10 @@ def test_metadata(
         filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
     )
     # check reports result
-    # no report in core yet
+    # TODO: change to t["key"]
+    assert metadata_report_minimal == next(
+        filter(lambda t: t["name"] == "Minimal", result["reports"])
+    )
 
 
 @pytest.mark.skip(reason="Not yet implemented")
@@ -48,7 +55,11 @@ def test_project_core(
 
 @pytest.mark.skip(reason="Not yet implemented")
 def test_project_misc(
-    client, response_template, metadata_topic_minimal, metadata_indicator_minimal
+    client,
+    response_template,
+    metadata_topic_minimal,
+    metadata_indicator_minimal,
+    metadata_report_minimal,
 ):
     response = client.get("/metadata?project=misc")
     assert response.status_code == 200
@@ -66,4 +77,7 @@ def test_project_misc(
         filter(lambda t: t["name"] == "Minimal", result["indicators"])
     )
     # check reports result
-    # no report in core yet
+    # TODO: change to t["key"]
+    assert metadata_report_minimal == next(
+        filter(lambda t: t["name"] == "Minimal", result["reports"])
+    )

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_metadata(
     client,
     response_template,
@@ -24,13 +21,9 @@ def test_metadata(
         filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
     )
     # check reports result
-    # TODO: change to t["key"]
-    assert metadata_report_minimal == next(
-        filter(lambda t: t["name"] == "Minimal", result["reports"])
-    )
+    # TODO: add report when a core report is implemented
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_project_core(
     client, response_template, building_count, metadata_mapping_saturation
 ):
@@ -40,20 +33,16 @@ def test_project_core(
     content = response.json()
     result = content.pop("result")
     assert content == response_template
+    for p in result["topics"] + result["indicators"] + result["reports"]:
+        assert p["project"] == "core"
     # check topics result
-    assert building_count == next(
-        filter(lambda t: t["key"] == "building_count", result["topics"])
-    )
+    assert len(result["topics"]) > 0
     # check indicators result
-    # TODO: change to t["key"]
-    assert metadata_mapping_saturation == next(
-        filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
-    )
+    assert len(result["indicators"]) > 0
     # check reports result
     # no report in core yet
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_project_misc(
     client,
     response_template,
@@ -67,16 +56,15 @@ def test_project_misc(
     content = response.json()
     result = content.pop("result")
     assert content == response_template
+    for p in result["topics"] + result["indicators"] + result["reports"]:
+        assert p["project"] == "misc"
     # check topics result
-    assert metadata_topic_minimal == next(
-        filter(lambda t: t["key"] == "minimal", result["topics"])
-    )
+    assert len(result["topics"]) > 0
     # check indicators result
-    # TODO: change to t["key"]
-    assert metadata_indicator_minimal == next(
-        filter(lambda t: t["name"] == "Minimal", result["indicators"])
-    )
+    assert len(result["indicators"]) > 0
     # check reports result
+    assert len(result["reports"]) > 0
+    # TODO: remove when a "core" report is implemented and added in test_metadata
     # TODO: change to t["key"]
     assert metadata_report_minimal == next(
         filter(lambda t: t["name"] == "Minimal", result["reports"])

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -3,7 +3,6 @@ def test_metadata(
     response_template,
     metadata_topic_building_count,
     metadata_indicator_mapping_saturation,
-    metadata_report_minimal,
 ):
     response = client.get("/metadata")
     assert response.status_code == 200
@@ -48,8 +47,6 @@ def test_project_core(
 def test_project_misc(
     client,
     response_template,
-    metadata_topic_minimal,
-    metadata_indicator_minimal,
     metadata_report_minimal,
 ):
     response = client.get("/metadata?project=misc")

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -1,0 +1,69 @@
+import pytest
+
+
+def test_metadata(
+    client, response_template, building_count, metadata_mapping_saturation
+):
+    response = client.get("/metadata")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    # check topics result
+    assert building_count == next(
+        filter(lambda t: t["key"] == "building_count", result["topics"])
+    )
+    # check indicators result
+    # TODO: change to t["key"]
+    assert metadata_mapping_saturation == next(
+        filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
+    )
+    # check reports result
+    # no report in core yet
+
+
+@pytest.mark.skip(reason="Not yet implemented")
+def test_project_core(
+    client, response_template, building_count, metadata_mapping_saturation
+):
+    response = client.get("/metadata?project=core")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    # check topics result
+    assert building_count == next(
+        filter(lambda t: t["key"] == "building_count", result["topics"])
+    )
+    # check indicators result
+    # TODO: change to t["key"]
+    assert metadata_mapping_saturation == next(
+        filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
+    )
+    # check reports result
+    # no report in core yet
+
+
+@pytest.mark.skip(reason="Not yet implemented")
+def test_project_misc(
+    client, response_template, metadata_topic_minimal, metadata_indicator_minimal
+):
+    response = client.get("/metadata?project=misc")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    # check topics result
+    assert metadata_topic_minimal == next(
+        filter(lambda t: t["key"] == "minimal", result["topics"])
+    )
+    # check indicators result
+    # TODO: change to t["key"]
+    assert metadata_indicator_minimal == next(
+        filter(lambda t: t["name"] == "Minimal", result["indicators"])
+    )
+    # check reports result
+    # no report in core yet

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -3,6 +3,7 @@ def test_metadata(
     response_template,
     metadata_topic_building_count,
     metadata_indicator_mapping_saturation,
+    metadata_report_multilevel_mapping_saturation,
 ):
     response = client.get("/metadata")
     assert response.status_code == 200
@@ -21,7 +22,10 @@ def test_metadata(
         == result["indicators"]["mapping-saturation"]
     )
     # check reports result
-    # TODO: add report when a core report is implemented
+    assert (
+        metadata_report_multilevel_mapping_saturation["multilevel-mapping-saturation"]
+        == result["reports"]["multilevel-mapping-saturation"]
+    )
 
 
 def test_project_core(
@@ -42,13 +46,12 @@ def test_project_core(
     # check indicators result
     assert len(result["indicators"]) > 0
     # check reports result
-    # no report in core yet
+    assert len(result["reports"]) > 0
 
 
 def test_project_misc(
     client,
     response_template,
-    metadata_report_minimal,
 ):
     response = client.get("/metadata?project=misc")
     assert response.status_code == 200
@@ -65,5 +68,3 @@ def test_project_misc(
     assert len(result["indicators"]) > 0
     # check reports result
     assert len(result["reports"]) > 0
-    # TODO: remove when a "core" report is implemented and added in test_metadata
-    assert metadata_report_minimal["minimal"] == result["reports"]["minimal"]

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -12,14 +12,9 @@ def test_metadata(
     result = content.pop("result")
     assert content == response_template
     # check topics result
-    assert building_count == next(
-        filter(lambda t: t["key"] == "building_count", result["topics"])
-    )
+    assert building_count == result["topics"]["building_count"]
     # check indicators result
-    # TODO: change to t["key"]
-    assert metadata_mapping_saturation == next(
-        filter(lambda t: t["name"] == "Mapping Saturation", result["indicators"])
-    )
+    assert metadata_mapping_saturation == result["indicators"]["mapping-saturation"]
     # check reports result
     # TODO: add report when a core report is implemented
 
@@ -33,8 +28,9 @@ def test_project_core(
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    for p in result["topics"] + result["indicators"] + result["reports"]:
-        assert p["project"] == "core"
+    for k in ("topics", "indicators", "reports"):
+        for p in result[k].values():
+            assert p["project"] == "core"
     # check topics result
     assert len(result["topics"]) > 0
     # check indicators result
@@ -56,8 +52,9 @@ def test_project_misc(
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    for p in result["topics"] + result["indicators"] + result["reports"]:
-        assert p["project"] == "misc"
+    for k in ("topics", "indicators", "reports"):
+        for p in result[k].values():
+            assert p["project"] == "misc"
     # check topics result
     assert len(result["topics"]) > 0
     # check indicators result
@@ -65,7 +62,4 @@ def test_project_misc(
     # check reports result
     assert len(result["reports"]) > 0
     # TODO: remove when a "core" report is implemented and added in test_metadata
-    # TODO: change to t["key"]
-    assert metadata_report_minimal == next(
-        filter(lambda t: t["name"] == "Minimal", result["reports"])
-    )
+    assert metadata_report_minimal == result["reports"]["minimal"]

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -1,8 +1,8 @@
 def test_metadata(
     client,
     response_template,
-    building_count,
-    metadata_mapping_saturation,
+    metadata_topic_building_count,
+    metadata_indicator_mapping_saturation,
     metadata_report_minimal,
 ):
     response = client.get("/metadata")
@@ -12,15 +12,21 @@ def test_metadata(
     result = content.pop("result")
     assert content == response_template
     # check topics result
-    assert building_count == result["topics"]["building_count"]
+    assert metadata_topic_building_count == result["topics"]["building_count"]
     # check indicators result
-    assert metadata_mapping_saturation == result["indicators"]["mapping-saturation"]
+    assert (
+        metadata_indicator_mapping_saturation
+        == result["indicators"]["mapping-saturation"]
+    )
     # check reports result
     # TODO: add report when a core report is implemented
 
 
 def test_project_core(
-    client, response_template, building_count, metadata_mapping_saturation
+    client,
+    response_template,
+    metadata_topic_building_count,
+    metadata_indicator_mapping_saturation,
 ):
     response = client.get("/metadata?project=core")
     assert response.status_code == 200

--- a/workers/tests/integrationtests/api/test_metadata.py
+++ b/workers/tests/integrationtests/api/test_metadata.py
@@ -11,10 +11,13 @@ def test_metadata(
     result = content.pop("result")
     assert content == response_template
     # check topics result
-    assert metadata_topic_building_count == result["topics"]["building_count"]
+    assert (
+        metadata_topic_building_count["building_count"]
+        == result["topics"]["building_count"]
+    )
     # check indicators result
     assert (
-        metadata_indicator_mapping_saturation
+        metadata_indicator_mapping_saturation["mapping-saturation"]
         == result["indicators"]["mapping-saturation"]
     )
     # check reports result
@@ -24,8 +27,6 @@ def test_metadata(
 def test_project_core(
     client,
     response_template,
-    metadata_topic_building_count,
-    metadata_indicator_mapping_saturation,
 ):
     response = client.get("/metadata?project=core")
     assert response.status_code == 200
@@ -65,4 +66,4 @@ def test_project_misc(
     # check reports result
     assert len(result["reports"]) > 0
     # TODO: remove when a "core" report is implemented and added in test_metadata
-    assert metadata_report_minimal == result["reports"]["minimal"]
+    assert metadata_report_minimal["minimal"] == result["reports"]["minimal"]

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -1,14 +1,14 @@
 import pytest
 
 
-def test(client, response_template, metadata_mapping_saturation):
+def test(client, response_template, metadata_indicator_mapping_saturation):
     response = client.get("/metadata/indicators/")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_mapping_saturation == result["mapping-saturation"]
+    assert metadata_indicator_mapping_saturation == result["mapping-saturation"]
 
 
 def test_by_key(client, response_template, metadata_indicator_minimal):
@@ -26,14 +26,14 @@ def test_by_key_not_found_error(client):
     assert response.status_code == 422
 
 
-def test_project_core(client, response_template, metadata_mapping_saturation):
+def test_project_core(client, response_template, metadata_indicator_mapping_saturation):
     response = client.get("/metadata/indicators/?project=core")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_mapping_saturation == result["mapping-saturation"]
+    assert metadata_indicator_mapping_saturation == result["mapping-saturation"]
     assert "minimal" not in result.keys()
 
 

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -12,6 +12,7 @@ def test(client, response_template, metadata_indicator_mapping_saturation):
         metadata_indicator_mapping_saturation["mapping-saturation"]
         == result["mapping-saturation"]
     )
+    assert "minimal" not in result.keys()
 
 
 def test_by_key(client, response_template, metadata_indicator_minimal):

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -8,9 +8,7 @@ def test(client, response_template, metadata_mapping_saturation):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_mapping_saturation == next(
-        filter(lambda r: r["name"] == "Mapping Saturation", result)
-    )
+    assert metadata_mapping_saturation == result["mapping-saturation"]
 
 
 def test_by_key(client, response_template, metadata_indicator_minimal):
@@ -35,10 +33,8 @@ def test_project_core(client, response_template, metadata_mapping_saturation):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_mapping_saturation == next(
-        filter(lambda r: r["name"] == "Mapping Saturation", result)
-    )
-    assert "Minimal" not in [r["name"] for r in result]
+    assert metadata_mapping_saturation == result["mapping-saturation"]
+    assert "minimal" not in result.keys()
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -28,7 +28,6 @@ def test_by_key_not_found_error(client):
     assert response.status_code == 422
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_project_core(client, response_template, metadata_mapping_saturation):
     response = client.get("/metadata/indicators/?project=core")
     assert response.status_code == 200

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -1,25 +1,6 @@
 import pytest
 
 
-@pytest.fixture
-def metadata_minimal():
-    return {
-        "name": "Minimal",
-        "description": "An minimal Indicator for testing purposes.",
-    }
-
-
-@pytest.fixture
-def metadata_mapping_saturation():
-    return {
-        "name": "Mapping Saturation",
-        "description": (
-            "Calculate if mapping has saturated. High saturation has been reached if "
-            + "the growth of the fitted curve is minimal."
-        ),
-    }
-
-
 def test(client, response_template, metadata_mapping_saturation):
     response = client.get("/metadata/indicators/")
     assert response.status_code == 200
@@ -32,14 +13,14 @@ def test(client, response_template, metadata_mapping_saturation):
     )
 
 
-def test_by_key(client, response_template, metadata_minimal):
+def test_by_key(client, response_template, metadata_indicator_minimal):
     response = client.get("/metadata/indicators/minimal")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert result == metadata_minimal
+    assert result == metadata_indicator_minimal
 
 
 def test_by_key_not_found_error(client):

--- a/workers/tests/integrationtests/api/test_metadata_indicators.py
+++ b/workers/tests/integrationtests/api/test_metadata_indicators.py
@@ -8,7 +8,10 @@ def test(client, response_template, metadata_indicator_mapping_saturation):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_indicator_mapping_saturation == result["mapping-saturation"]
+    assert (
+        metadata_indicator_mapping_saturation["mapping-saturation"]
+        == result["mapping-saturation"]
+    )
 
 
 def test_by_key(client, response_template, metadata_indicator_minimal):
@@ -33,7 +36,10 @@ def test_project_core(client, response_template, metadata_indicator_mapping_satu
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_indicator_mapping_saturation == result["mapping-saturation"]
+    assert (
+        metadata_indicator_mapping_saturation["mapping-saturation"]
+        == result["mapping-saturation"]
+    )
     assert "minimal" not in result.keys()
 
 

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test(client, response_template, metadata_report_minimal):
+def test(client, response_template):
     response = client.get("/metadata/reports/")
     assert response.status_code == 200
 

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -6,11 +6,10 @@ def test(client, response_template, metadata_report_minimal):
     assert response.status_code == 200
 
     content = response.json()
-    result = content.pop("result")
+    content.pop("result")
     assert content == response_template
-    assert metadata_report_minimal == next(
-        filter(lambda r: r["name"] == "Minimal", result)
-    )
+    # TODO: add assert (comparable to test_indicators::test)
+    #  as soon as a report is considered "core"
 
 
 def test_by_key(client, response_template, metadata_report_minimal):
@@ -28,7 +27,6 @@ def test_by_key_not_found_error(client):
     assert response.status_code == 422
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_project_misc(client, response_template, metadata_report_minimal):
     response = client.get("/metadata/reports/?project=misc")
     assert response.status_code == 200
@@ -39,7 +37,6 @@ def test_project_misc(client, response_template, metadata_report_minimal):
     assert metadata_report_minimal == next(
         filter(lambda r: r["name"] == "Minimal", result)
     )
-    assert "Minimal" not in [r["name"] for r in result]
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+def test(client, response_template, metadata_report_minimal):
+    response = client.get("/metadata/reports/")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    assert metadata_report_minimal == next(
+        filter(lambda r: r["name"] == "Minimal", result)
+    )
+
+
+def test_by_key(client, response_template, metadata_report_minimal):
+    response = client.get("/metadata/reports/minimal")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    assert result == metadata_report_minimal
+
+
+def test_by_key_not_found_error(client):
+    response = client.get("/metadata/reports/foo")
+    assert response.status_code == 422
+
+
+@pytest.mark.skip(reason="Not yet implemented")
+def test_project_misc(client, response_template, metadata_report_minimal):
+    response = client.get("/metadata/reports/?project=misc")
+    assert response.status_code == 200
+
+    content = response.json()
+    result = content.pop("result")
+    assert content == response_template
+    assert metadata_report_minimal == next(
+        filter(lambda r: r["name"] == "Minimal", result)
+    )
+    assert "Minimal" not in [r["name"] for r in result]
+
+
+@pytest.mark.skip(reason="Not yet implemented")
+def test_project_not_found_error(client):
+    response = client.get("/metadata/reports/?project=foo")
+    assert response.status_code == 404  # Not Found
+    # content = response.json()

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -34,9 +34,7 @@ def test_project_misc(client, response_template, metadata_report_minimal):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_report_minimal == next(
-        filter(lambda r: r["name"] == "Minimal", result)
-    )
+    assert metadata_report_minimal == result["minimal"]
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -1,15 +1,18 @@
 import pytest
 
 
-def test(client, response_template):
+def test(client, response_template, metadata_report_multilevel_mapping_saturation):
     response = client.get("/metadata/reports/")
     assert response.status_code == 200
 
     content = response.json()
-    content.pop("result")
+    result = content.pop("result")
     assert content == response_template
-    # TODO: add assert (comparable to test_indicators::test)
-    #  as soon as a report is considered "core"
+    assert (
+        metadata_report_multilevel_mapping_saturation["multilevel-mapping-saturation"]
+        == result["multilevel-mapping-saturation"]
+    )
+    assert "minimal" not in result.keys()
 
 
 def test_by_key(client, response_template, metadata_report_minimal):
@@ -27,14 +30,20 @@ def test_by_key_not_found_error(client):
     assert response.status_code == 422
 
 
-def test_project_misc(client, response_template, metadata_report_minimal):
-    response = client.get("/metadata/reports/?project=misc")
+def test_project_core(
+    client, response_template, metadata_report_multilevel_mapping_saturation
+):
+    response = client.get("/metadata/reports/?project=core")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_report_minimal["minimal"] == result["minimal"]
+    assert (
+        metadata_report_multilevel_mapping_saturation["multilevel-mapping-saturation"]
+        == result["multilevel-mapping-saturation"]
+    )
+    assert "minimal" not in result.keys()
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/integrationtests/api/test_metadata_reports.py
+++ b/workers/tests/integrationtests/api/test_metadata_reports.py
@@ -34,7 +34,7 @@ def test_project_misc(client, response_template, metadata_report_minimal):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_report_minimal == result["minimal"]
+    assert metadata_report_minimal["minimal"] == result["minimal"]
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -8,7 +8,7 @@ def test_metadata_topic(client, response_template, metadata_topic_building_count
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_topic_building_count == result["building_count"]
+    assert metadata_topic_building_count["building_count"] == result["building_count"]
     assert "minimal" not in result.keys()
 
 
@@ -21,7 +21,7 @@ def test_metadata_topic_project_core(
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert metadata_topic_building_count == result["building_count"]
+    assert metadata_topic_building_count["building_count"] == result["building_count"]
     assert "minimal" not in result.keys()
 
 

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -1,26 +1,6 @@
 import pytest
 
 
-@pytest.fixture
-def building_count():
-    return {
-        "key": "building_count",
-        "name": "Building Count",
-        "description": (
-            "All buildings as defined by all objects tagged with 'building=*'."
-        ),
-        "endpoint": "elements/count",
-        "filter": "building=* and building!=no and geometry:polygon",
-        "indicators": ["mapping-saturation", "currentness", "attribute-completeness"],
-        "ratio_filter": (
-            "building=* and building!=no and geometry:polygon and height=* or "
-            + "building:levels=*"
-        ),
-        "project": "core",
-        "source": None,  # TODO: Should not be in response if None
-    }
-
-
 def test_metadata_topic(client, response_template, building_count):
     response = client.get("/metadata/topics")
     assert response.status_code == 200

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -15,7 +15,6 @@ def test_metadata_topic(client, response_template, building_count):
     # assert "minimal" not in [topic["key"] for topic in result]
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_metadata_topic_project_core(client, response_template, building_count):
     response = client.get("/metadata/topics/?project=core")
     assert response.status_code == 200
@@ -29,7 +28,6 @@ def test_metadata_topic_project_core(client, response_template, building_count):
     assert "minimal" not in [topic["key"] for topic in result]
 
 
-@pytest.mark.skip(reason="Not yet implemented")
 def test_metadata_topic_project_experimental(client, response_template):
     response = client.get("/metadata/topics/?project=experimental")
     assert response.status_code == 200

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -1,26 +1,28 @@
 import pytest
 
 
-def test_metadata_topic(client, response_template, building_count):
+def test_metadata_topic(client, response_template, metadata_topic_building_count):
     response = client.get("/metadata/topics")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert building_count == result["building_count"]
+    assert metadata_topic_building_count == result["building_count"]
     # TODO
     # assert "minimal" not in [topic["key"] for topic in result]
 
 
-def test_metadata_topic_project_core(client, response_template, building_count):
+def test_metadata_topic_project_core(
+    client, response_template, metadata_topic_building_count
+):
     response = client.get("/metadata/topics/?project=core")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert building_count == result["building_count"]
+    assert metadata_topic_building_count == result["building_count"]
     assert "minimal" not in result.keys()
 
 
@@ -42,14 +44,16 @@ def test_metadata_topic_project_not_found_error(client):
     # content = response.json()
 
 
-def test_metadata_topic_by_key(client, response_template, building_count):
+def test_metadata_topic_by_key(
+    client, response_template, metadata_topic_building_count
+):
     response = client.get("/metadata/topics/building_count")
     assert response.status_code == 200
 
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert result == building_count
+    assert result == metadata_topic_building_count
 
 
 def test_metadata_topic_by_key_not_found_error(client):

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -9,8 +9,7 @@ def test_metadata_topic(client, response_template, metadata_topic_building_count
     result = content.pop("result")
     assert content == response_template
     assert metadata_topic_building_count == result["building_count"]
-    # TODO
-    # assert "minimal" not in [topic["key"] for topic in result]
+    assert "minimal" not in result.keys()
 
 
 def test_metadata_topic_project_core(

--- a/workers/tests/integrationtests/api/test_metadata_topics.py
+++ b/workers/tests/integrationtests/api/test_metadata_topics.py
@@ -8,9 +8,7 @@ def test_metadata_topic(client, response_template, building_count):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert building_count == next(
-        filter(lambda t: t["key"] == "building_count", result)
-    )
+    assert building_count == result["building_count"]
     # TODO
     # assert "minimal" not in [topic["key"] for topic in result]
 
@@ -22,10 +20,8 @@ def test_metadata_topic_project_core(client, response_template, building_count):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert building_count == next(
-        filter(lambda t: t["key"] == "building_count", result)
-    )
-    assert "minimal" not in [topic["key"] for topic in result]
+    assert building_count == result["building_count"]
+    assert "minimal" not in result.keys()
 
 
 def test_metadata_topic_project_experimental(client, response_template):
@@ -35,8 +31,8 @@ def test_metadata_topic_project_experimental(client, response_template):
     content = response.json()
     result = content.pop("result")
     assert content == response_template
-    assert "building_count" not in [topic["key"] for topic in result]
-    assert "minimal" not in [topic["key"] for topic in result]
+    assert "building_count" not in result.keys()
+    assert "minimal" not in result.keys()
 
 
 @pytest.mark.skip(reason="Not yet implemented")

--- a/workers/tests/unittests/api/test_response_models.py
+++ b/workers/tests/unittests/api/test_response_models.py
@@ -34,9 +34,9 @@ def test_metadata_topics_fail():
         TopicResponse(result={"foo": "bar"})
 
 
-def test_metadata_topics_list(topics_list):
-    response = TopicListResponse(result=topics_list)
-    assert response.result == topics_list
+def test_metadata_topics_list(topic_definitions):
+    response = TopicListResponse(result=topic_definitions)
+    assert response.result == topic_definitions
 
 
 def test_metadata_indicators(indicator_metadata_minimal):

--- a/workers/tests/unittests/api/test_response_models.py
+++ b/workers/tests/unittests/api/test_response_models.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from ohsome_quality_analyst import __version__
 from ohsome_quality_analyst.api.response_models import (
     IndicatorMetadataResponse,
+    ReportMetadataResponse,
     ResponseBase,
     TopicMetadataResponse,
 )
@@ -16,12 +17,12 @@ def test_base():
     assert response.attribution == {"url": ATTRIBUTION_URL}
 
 
-def test_metadata_topics(topic_building_count):
-    response = TopicMetadataResponse(result=topic_building_count)
-    assert response.result == topic_building_count
+def test_metadata_topics(metadata_topic_building_count):
+    response = TopicMetadataResponse(result=metadata_topic_building_count)
+    assert response.result == metadata_topic_building_count
 
 
-def test_metadata_topics_fail():
+def test_metadata_topics_fail(topic_building_count):
     with pytest.raises(ValidationError):
         TopicMetadataResponse(result="")
     with pytest.raises(ValidationError):
@@ -30,6 +31,8 @@ def test_metadata_topics_fail():
         TopicMetadataResponse(result={})
     with pytest.raises(ValidationError):
         TopicMetadataResponse(result={"foo": "bar"})
+    with pytest.raises(ValidationError):
+        TopicMetadataResponse(result={"foo": topic_building_count})
 
 
 def test_metadata_topics_list(topic_definitions):
@@ -37,12 +40,12 @@ def test_metadata_topics_list(topic_definitions):
     assert response.result == topic_definitions
 
 
-def test_metadata_indicators(indicator_metadata_minimal):
-    response = IndicatorMetadataResponse(result=indicator_metadata_minimal)
-    assert response.result == indicator_metadata_minimal
+def test_metadata_indicators(metadata_indicator_minimal):
+    response = IndicatorMetadataResponse(result=metadata_indicator_minimal)
+    assert response.result == metadata_indicator_minimal
 
 
-def test_metadata_indicators_fail():
+def test_metadata_indicators_fail(metadata_indicator_minimal):
     with pytest.raises(ValidationError):
         IndicatorMetadataResponse(result="")
     with pytest.raises(ValidationError):
@@ -51,8 +54,33 @@ def test_metadata_indicators_fail():
         IndicatorMetadataResponse(result={})
     with pytest.raises(ValidationError):
         IndicatorMetadataResponse(result={"foo": "bar"})
+    with pytest.raises(ValidationError):
+        IndicatorMetadataResponse(result={"foo": metadata_indicator_minimal})
 
 
 def test_metadata_indicators_list(indicators_metadata):
     response = IndicatorMetadataResponse(result=indicators_metadata)
     assert response.result == indicators_metadata
+
+
+def test_metadata_reports(metadata_report_minimal):
+    response = ReportMetadataResponse(result=metadata_report_minimal)
+    assert response.result == metadata_report_minimal
+
+
+def test_metadata_reports_fail(metadata_report_minimal):
+    with pytest.raises(ValidationError):
+        ReportMetadataResponse(result="")
+    with pytest.raises(ValidationError):
+        ReportMetadataResponse(result="bar")
+    with pytest.raises(ValidationError):
+        ReportMetadataResponse(result={})
+    with pytest.raises(ValidationError):
+        ReportMetadataResponse(result={"foo": "bar"})
+    with pytest.raises(ValidationError):
+        ReportMetadataResponse(result={"foo": metadata_report_minimal})
+
+
+def test_metadata_reports_list(reports_metadata):
+    response = ReportMetadataResponse(result=reports_metadata)
+    assert response.result == reports_metadata

--- a/workers/tests/unittests/api/test_response_models.py
+++ b/workers/tests/unittests/api/test_response_models.py
@@ -3,10 +3,10 @@ from pydantic import ValidationError
 
 from ohsome_quality_analyst import __version__
 from ohsome_quality_analyst.api.response_models import (
-    IndicatorMetadataListResponse,
+    AllIndicatorMetadataResponse,
+    AllTopicsResponse,
     IndicatorMetadataResponse,
     ResponseBase,
-    TopicListResponse,
     TopicResponse,
 )
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
@@ -35,7 +35,7 @@ def test_metadata_topics_fail():
 
 
 def test_metadata_topics_list(topic_definitions):
-    response = TopicListResponse(result=topic_definitions)
+    response = AllTopicsResponse(result=topic_definitions)
     assert response.result == topic_definitions
 
 
@@ -56,5 +56,5 @@ def test_metadata_indicators_fail():
 
 
 def test_metadata_indicators_list(indicators_metadata):
-    response = IndicatorMetadataListResponse(result=indicators_metadata)
+    response = AllIndicatorMetadataResponse(result=indicators_metadata)
     assert response.result == indicators_metadata

--- a/workers/tests/unittests/api/test_response_models.py
+++ b/workers/tests/unittests/api/test_response_models.py
@@ -3,11 +3,9 @@ from pydantic import ValidationError
 
 from ohsome_quality_analyst import __version__
 from ohsome_quality_analyst.api.response_models import (
-    AllIndicatorMetadataResponse,
-    AllTopicsResponse,
     IndicatorMetadataResponse,
     ResponseBase,
-    TopicResponse,
+    TopicMetadataResponse,
 )
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
 
@@ -19,23 +17,23 @@ def test_base():
 
 
 def test_metadata_topics(topic_building_count):
-    response = TopicResponse(result=topic_building_count)
+    response = TopicMetadataResponse(result=topic_building_count)
     assert response.result == topic_building_count
 
 
 def test_metadata_topics_fail():
     with pytest.raises(ValidationError):
-        TopicResponse(result="")
+        TopicMetadataResponse(result="")
     with pytest.raises(ValidationError):
-        TopicResponse(result="bar")
+        TopicMetadataResponse(result="bar")
     with pytest.raises(ValidationError):
-        TopicResponse(result={})
+        TopicMetadataResponse(result={})
     with pytest.raises(ValidationError):
-        TopicResponse(result={"foo": "bar"})
+        TopicMetadataResponse(result={"foo": "bar"})
 
 
 def test_metadata_topics_list(topic_definitions):
-    response = AllTopicsResponse(result=topic_definitions)
+    response = TopicMetadataResponse(result=topic_definitions)
     assert response.result == topic_definitions
 
 
@@ -56,5 +54,5 @@ def test_metadata_indicators_fail():
 
 
 def test_metadata_indicators_list(indicators_metadata):
-    response = AllIndicatorMetadataResponse(result=indicators_metadata)
+    response = IndicatorMetadataResponse(result=indicators_metadata)
     assert response.result == indicators_metadata

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -77,22 +77,37 @@ class TestDefinitions(unittest.TestCase):
         self.assertEqual(topics, ("minimal",))
 
 
-def test_load_topic_definitions():
+def test_load_topic_definition():
     topics = definitions.load_topic_definitions()
     for topic in topics:
         assert isinstance(topics[topic], TopicDefinition)
 
 
-def test_get_topic_definitions():
+def test_get_topic_definition():
     topic = definitions.get_topic_definition("minimal")
     assert isinstance(topic, TopicDefinition)
 
 
-def test_get_topic_definitions_not_found_error():
+def test_get_topic_definition_not_found_error():
     with pytest.raises(KeyError):
         definitions.get_topic_definition("foo")
     with pytest.raises(KeyError):
         definitions.get_topic_definition(None)
+
+
+def test_get_topic_definitions():
+    topics = definitions.get_topic_definitions()
+    assert isinstance(topics, list)
+    for topic in topics:
+        assert isinstance(topic, TopicDefinition)
+
+
+def test_get_topic_definitions_with_project():
+    topics = definitions.get_topic_definitions("core")
+    assert isinstance(topics, list)
+    for topic in topics:
+        assert isinstance(topic, TopicDefinition)
+        assert topic.project == "core"
 
 
 def test_load_metadata_indicator():

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -97,45 +97,45 @@ def test_get_topic_definition_not_found_error():
 
 def test_get_topic_definitions():
     topics = definitions.get_topic_definitions()
-    assert isinstance(topics, list)
-    for topic in topics:
+    assert isinstance(topics, dict)
+    for topic in topics.values():
         assert isinstance(topic, TopicDefinition)
 
 
 def test_get_indicator_definitions():
     indicators = definitions.get_indicator_definitions()
-    assert isinstance(indicators, list)
-    for indicator in indicators:
+    assert isinstance(indicators, dict)
+    for indicator in indicators.values():
         assert isinstance(indicator, IndicatorMetadata)
 
 
 def test_get_indicator_definitions_with_project():
     indicators = definitions.get_indicator_definitions("core")
-    assert isinstance(indicators, list)
-    for indicator in indicators:
+    assert isinstance(indicators, dict)
+    for indicator in indicators.values():
         assert isinstance(indicator, IndicatorMetadata)
         assert indicator.project == "core"
 
 
 def test_get_report_definitions():
     reports = definitions.get_report_definitions()
-    assert isinstance(reports, list)
-    for report in reports:
+    assert isinstance(reports, dict)
+    for report in reports.values():
         assert isinstance(report, ReportMetadata)
 
 
 def test_get_report_definitions_with_project():
     reports = definitions.get_report_definitions("core")
-    assert isinstance(reports, list)
-    for report in reports:
+    assert isinstance(reports, dict)
+    for report in reports.values():
         assert isinstance(report, ReportMetadata)
         assert report.project == "core"
 
 
 def test_get_topic_definitions_with_project():
     topics = definitions.get_topic_definitions("core")
-    assert isinstance(topics, list)
-    for topic in topics:
+    assert isinstance(topics, dict)
+    for topic in topics.values():
         assert isinstance(topic, TopicDefinition)
         assert topic.project == "core"
 

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -102,6 +102,21 @@ def test_get_topic_definitions():
         assert isinstance(topic, TopicDefinition)
 
 
+def test_get_indicator_definitions():
+    indicators = definitions.get_indicator_definitions()
+    assert isinstance(indicators, list)
+    for indicator in indicators:
+        assert isinstance(indicator, IndicatorMetadata)
+
+
+def test_get_indicator_definitions_with_project():
+    indicators = definitions.get_indicator_definitions("core")
+    assert isinstance(indicators, list)
+    for indicator in indicators:
+        assert isinstance(indicator, IndicatorMetadata)
+        assert indicator.project == "core"
+
+
 def test_get_topic_definitions_with_project():
     topics = definitions.get_topic_definitions("core")
     assert isinstance(topics, list)

--- a/workers/tests/unittests/test_definitions.py
+++ b/workers/tests/unittests/test_definitions.py
@@ -117,6 +117,21 @@ def test_get_indicator_definitions_with_project():
         assert indicator.project == "core"
 
 
+def test_get_report_definitions():
+    reports = definitions.get_report_definitions()
+    assert isinstance(reports, list)
+    for report in reports:
+        assert isinstance(report, ReportMetadata)
+
+
+def test_get_report_definitions_with_project():
+    reports = definitions.get_report_definitions("core")
+    assert isinstance(reports, list)
+    for report in reports:
+        assert isinstance(report, ReportMetadata)
+        assert report.project == "core"
+
+
 def test_get_topic_definitions_with_project():
     topics = definitions.get_topic_definitions("core")
     assert isinstance(topics, list)


### PR DESCRIPTION
### Description
This PR introduces:
- the `/metadata` endpoint containing all metadata from `/metadata/{topics,indicators,reports}`
- the `/metadata/reports` endpoint
- limit metadata endpoints by projects
- the use of the `core` project as default for metadata requests
- assigns indicators and reports to projects

### Corresponding issue
- Related to #485 
- Closes #495

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
