### PR TITLE
feat(api): homogenize response schema for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - remove API endpoints `/indicators`, `/reports`, `/datasets` and `/fid-fields` ([#554])
 - discontinue support GeoJSON Geometry as value for `bpolys` parameters ([#554])
 - rename `PoiDensity` indicator to `density` ([#544])
+- homogenize API response schema for errors ([#562])
 
 ### Bug Fixes
 
@@ -75,7 +76,19 @@
   - E.g. `{"name": "mapping-saturation", "bpolys": {...}, "topic": {"key": "my-key", "name": "my-name", "description": "my-description", "data": {...}}"`
 - API endpoint `/indicator` and `/report` do not support GET request anymore. Change request to those endpoints to use the POST method ([#516]).
 - to compute an indicator or report request the new API endpoints `/indicators/{key}` and `/reports/{key}` ([#554])
-
+- to compute an indicator or report request the new API endpoints `/indicators/{key}` and `/reports/{key}` ([#554])
+- all error message have following schema ([#562]):
+```json
+{
+  "apiVersion": "__version__",
+  "type": "exception.name",
+  "detail": [
+    {
+      "msg": "exception.message"
+    }
+  ]
+}
+```
 | old API parameter | new API parameter |
 | ---               | ---               |
 | `layerKey`        | `topic`           |
@@ -119,8 +132,10 @@
 [#552]: https://github.com/GIScience/ohsome-quality-analyst/pull/552
 [#554]: https://github.com/GIScience/ohsome-quality-analyst/pull/554
 [#556]: https://github.com/GIScience/ohsome-quality-analyst/pull/556
+[#559]: https://github.com/GIScience/ohsome-quality-analyst/pull/549
 [#559]: https://github.com/GIScience/ohsome-quality-analyst/pull/559
 [#561]: https://github.com/GIScience/ohsome-quality-analyst/pull/561
+[#562]: https://github.com/GIScience/ohsome-quality-analyst/pull/562
 [#563]: https://github.com/GIScience/ohsome-quality-analyst/pull/563
 
 ## 0.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
   ]
 }
 ```
+
 | old API parameter | new API parameter |
 | ---               | ---               |
 | `layerKey`        | `topic`           |
@@ -132,7 +133,6 @@
 [#552]: https://github.com/GIScience/ohsome-quality-analyst/pull/552
 [#554]: https://github.com/GIScience/ohsome-quality-analyst/pull/554
 [#556]: https://github.com/GIScience/ohsome-quality-analyst/pull/556
-[#559]: https://github.com/GIScience/ohsome-quality-analyst/pull/549
 [#559]: https://github.com/GIScience/ohsome-quality-analyst/pull/559
 [#561]: https://github.com/GIScience/ohsome-quality-analyst/pull/561
 [#562]: https://github.com/GIScience/ohsome-quality-analyst/pull/562

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -153,10 +153,9 @@ class CustomJSONResponse(JSONResponse):
 
 
 @app.exception_handler(RequestValidationError)
-@app.exception_handler(ValidationError)
 async def validation_exception_handler(
-    request: Request,
-    exception: RequestValidationError | ValidationError,
+    _: Request,
+    exception: RequestValidationError,
 ):
     """Exception handler for validation exceptions."""
     return JSONResponse(
@@ -164,8 +163,8 @@ async def validation_exception_handler(
         content=jsonable_encoder(
             {
                 "apiVersion": __version__,
-                "detail": exception.errors(),
                 "type": "RequestValidationError",
+                "detail": exception.errors(),
             },
         ),
     )
@@ -177,24 +176,28 @@ async def validation_exception_handler(
 @app.exception_handler(RasterDatasetNotFoundError)
 @app.exception_handler(RasterDatasetUndefinedError)
 @app.exception_handler(SizeRestrictionError)
+@app.exception_handler(ValidationError)
 async def oqt_exception_handler(
-    request: Request,
-    exception: (
-        HexCellsNotFoundError
-        | TopicDataSchemaError
-        | OhsomeApiError
-        | RasterDatasetNotFoundError
-        | RasterDatasetUndefinedError
-        | SizeRestrictionError
-    ),
+    _: Request,
+    exception: HexCellsNotFoundError
+    | TopicDataSchemaError
+    | OhsomeApiError
+    | RasterDatasetNotFoundError
+    | RasterDatasetUndefinedError
+    | SizeRestrictionError
+    | ValidationError,
 ):
     """Exception handler for OQT exceptions."""
     return JSONResponse(
         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
         content={
             "apiVersion": __version__,
-            "detail": exception.message,
             "type": exception.name,
+            "detail": [
+                {
+                    "msg": exception.message,
+                },
+            ],
         },
     )
 

--- a/workers/ohsome_quality_analyst/utils/exceptions.py
+++ b/workers/ohsome_quality_analyst/utils/exceptions.py
@@ -4,10 +4,8 @@ from schema import SchemaError
 
 class ValidationError(Exception):
     def __init__(self):
+        self.name = ""
         self.message = ""
-
-    def errors(self):
-        return self.message
 
 
 class GeoJSONError(ValidationError):


### PR DESCRIPTION
### Description

Homogenize API response schema for errors.

Default JSON error like ValidationErrors by Pydantic/FastAPI:
```json
{
    "detail": [
        {
            "loc": [
                "path",
                "item_id"
            ],
            "msg": "value is not a valid integer",
            "type": "type_error.integer"
        }
    ]
}
```

The PR changes the response schema for errors in OQT to:
```json
{
    "apiVersion": __version__,
    "type": "type_error.integer"
    "detail": [
        {
            "loc": [
                "path",
                "item_id"
            ],
            "msg": "value is not a valid integer",
            "type": "type_error.integer"
        }
    ]
}
```
Whereas  `["detail"]["loc"]` and `["detail"]["type"]` are optional and only in use for Request Validation Errors raised by Pydantic/FastAPI.


### Corresponding issue
Closes #

### New or changed dependencies
-

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
- [x] tests