### PR TITLE
fix(swagger): root_path is used for static files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - build(poetry): add primary and supplemental source ([#576])
 - build: update `requests` to "^2.31.0" ([#576])
 - build: remove unused dependency `dacite` ([#576])
-- swagger: serve Swagger UI files not via CDN ([#581])
+- swagger: serve Swagger UI files not via CDN ([#581], [#593])
 - tests(vcr): don't record local requests and change cassettes directory structure ([#579])
 
 ### How to Upgrade
@@ -147,6 +147,7 @@
 [#578]: https://github.com/GIScience/ohsome-quality-analyst/pull/578
 [#579]: https://github.com/GIScience/ohsome-quality-analyst/pull/579
 [#581]: https://github.com/GIScience/ohsome-quality-analyst/pull/581
+[#593]: https://github.com/GIScience/ohsome-quality-analyst/pull/593
 
 ## 0.14.2
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -158,14 +158,15 @@ app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 
 @app.get("/docs", include_in_schema=False)
-async def custom_swagger_ui_html():
+async def custom_swagger_ui_html(request: Request):
+    root_path = request.scope.get("root_path")
     return get_swagger_ui_html(
         openapi_url=app.openapi_url,
         title=app.title + " - Swagger UI",
         oauth2_redirect_url=app.swagger_ui_oauth2_redirect_url,
-        swagger_js_url="/static/swagger-ui-bundle.js",
-        swagger_css_url="/static/swagger-ui.css",
-        swagger_favicon_url="/static/favicon-32x32.png",
+        swagger_js_url=root_path + "/static/swagger-ui-bundle.js",
+        swagger_css_url=root_path + "/static/swagger-ui.css",
+        swagger_favicon_url=root_path + "/static/favicon-32x32.png",
     )
 
 
@@ -175,12 +176,13 @@ async def swagger_ui_redirect():
 
 
 @app.get("/redoc", include_in_schema=False)
-async def redoc_html():
+async def redoc_html(request: Request):
+    root_path = request.scope.get("root_path")
     return get_redoc_html(
         openapi_url=app.openapi_url,
         title=app.title + " - ReDoc",
-        redoc_js_url="/static/redoc.standalone.js",
-        redoc_favicon_url="/static/favicon-32x32.png",
+        redoc_js_url=root_path + "/static/redoc.standalone.js",
+        redoc_favicon_url=root_path + "/static/favicon-32x32.png",
     )
 
 


### PR DESCRIPTION
### Description
In deployment we are using a [Proxy](https://fastapi.tiangolo.com/advanced/behind-a-proxy/#setting-the-root_path-in-the-fastapi-app). Therefore we need to make sure all our paths are prepended with this proxy path. This is automatically done for the API, but not for swagger. This PR fixes this issue.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
