### PR TITLE
feat(api): add response model for indicator

### DIFF
--- a/ohsome_quality_analyst/api/response_models.py
+++ b/ohsome_quality_analyst/api/response_models.py
@@ -8,6 +8,7 @@ from ohsome_quality_analyst.api.request_models import (
 )
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
+from ohsome_quality_analyst.indicators.models import Result as IndicatorResult
 from ohsome_quality_analyst.projects.definitions import ProjectEnum
 from ohsome_quality_analyst.projects.models import Project
 from ohsome_quality_analyst.quality_dimensions.definitions import QualityDimensionEnum
@@ -26,6 +27,22 @@ class ResponseBase(BaseModel):
         frozen = True
         extra = "forbid"
         allow_population_by_field_name = True
+
+
+class IndicatorResponse(ResponseBase):
+    class IndicatorResultSchema(BaseModel):
+        metadata: IndicatorMetadata
+        topic: TopicDefinition
+        quality_dimensions: QualityDimension
+        project: Project
+        result: IndicatorResult
+
+        class Config:
+            alias_generator = snake_to_hyphen
+            frozen = True
+            extra = "forbid"
+
+    result: IndicatorResultSchema
 
 
 class TopicMetadataResponse(ResponseBase):


### PR DESCRIPTION
### Description
Two response formats for an indicator result are supported:
- GeoJSON
- JSON

Check out https://github.com/developmentseed/geojson-pydantic

### Corresponding issue
Closes #

### New or changed dependencies
-

### Checklist
- [ ] I have updated my branch to `main` (e.g. through `git rebase main`)
- [ ] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [ ] I have commented my code
- [ ] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)
- [ ] Add response model for GeoJSON
- [ ] Remove testing the response using `schema` in tests. Validation is done by pydantic.

