### PR TITLE
chore(api): use plural in JSON indicator response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@
 #### API
 
 - add `/indicators/{key}` and `/reports/{key}` endpoints ([#554])
-    - support JSON in addition to GeoJSON responses ([#582])
+    - support JSON in addition to GeoJSON responses ([#582], [#627])
 - add `/metadata/topic` endpoint ([#519])
 - add `/metadata/indicators` endpoint ([#533])
 - add `/metadata/reports` endpoint ([#545])
@@ -180,6 +180,7 @@
 [#603]: https://github.com/GIScience/ohsome-quality-analyst/pull/603
 [#605]: https://github.com/GIScience/ohsome-quality-analyst/pull/605
 [#625]: https://github.com/GIScience/ohsome-quality-analyst/pull/625
+[#627]: https://github.com/GIScience/ohsome-quality-analyst/pull/627
 
 ## 0.14.2
 

--- a/workers/ohsome_quality_analyst/api/api.py
+++ b/workers/ohsome_quality_analyst/api/api.py
@@ -320,13 +320,13 @@ async def post_indicator(
     #   factor out logic and decision to base/indicator.py and oqt.py
     #   base/indicator.py should have `as_dict` alongside `as_feature`
     if request.headers["accept"] == MEDIA_TYPE_JSON:
-        response["result"] = []
+        response["results"] = []
         # TODO: remove check once only FeatureCollection is supported
         if isinstance(geojson_object, FeatureCollection):
             for feature in geojson_object.features:
-                response["result"].append(feature.properties)
+                response["results"].append(feature.properties)
         else:
-            response["result"].append(geojson_object.properties)
+            response["results"].append(geojson_object.properties)
         return CustomJSONResponse(content=response, media_type=MEDIA_TYPE_JSON)
     elif request.headers["accept"] == MEDIA_TYPE_GEOJSON:
         response.update(geojson_object)

--- a/workers/tests/integrationtests/api/test_indicators.py
+++ b/workers/tests/integrationtests/api/test_indicators.py
@@ -22,7 +22,7 @@ RESPONSE_SCHEMA_JSON = Schema(
             "url": str,
             Optional("text"): str,
         },
-        "result": [
+        "results": [
             {
                 Optional("id"): Or(str, int),
                 "metadata": {
@@ -196,7 +196,7 @@ def test_include_svg(client, bpolys, topic_key_minimal, headers, schema):
     content = response.json()
     assert schema.is_valid(content)
     if schema.name == "json":
-        for result in content["result"]:
+        for result in content["results"]:
             assert "svg" in result["result"].keys()
     elif schema.name == "geojson":
         for feature in content["features"]:
@@ -213,7 +213,7 @@ def test_include_svg(client, bpolys, topic_key_minimal, headers, schema):
     content = response.json()
     assert schema.is_valid(content)
     if schema.name == "json":
-        for result in content["result"]:
+        for result in content["results"]:
             assert "svg" not in result["result"].keys()
     elif schema.name == "geojson":
         for feature in content["features"]:
@@ -229,7 +229,7 @@ def test_include_svg(client, bpolys, topic_key_minimal, headers, schema):
     content = response.json()
     assert schema.is_valid(content)
     if schema.name == "json":
-        for result in content["result"]:
+        for result in content["results"]:
             assert "svg" not in result["result"].keys()
     elif schema.name == "geojson":
         for feature in content["features"]:


### PR DESCRIPTION
### Description
JSON response for `/indicators/{key}` now uses `results` instead of `result` on the top layer, since the value is an array with potentially multiple results.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)