### PR TITLE
refactor(api)!: computing mapping-saturation indicator for given data is now a separate endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking
 
 - api: remove `dataset`, `featureId` and `fidField` parameter ([#634])
+- api: computing mapping-saturation indicator for given data is now a separate endpoint ([#642])
 - cli: remove CLI ([#634])
 
 ### Other Changes
@@ -24,6 +25,7 @@
 [#633]: https://github.com/GIScience/ohsome-quality-analyst/pull/633
 [#634]: https://github.com/GIScience/ohsome-quality-analyst/pull/634
 [#639]: https://github.com/GIScience/ohsome-quality-analyst/pull/639
+[#642]: https://github.com/GIScience/ohsome-quality-analyst/pull/642
 
 ## 0.15.0
 

--- a/workers/tests/integrationtests/api/test_indicator_geojson_io.py
+++ b/workers/tests/integrationtests/api/test_indicator_geojson_io.py
@@ -167,9 +167,9 @@ class TestApiIndicatorIo(unittest.TestCase):
             },
         }
         response = self.client.post(
-            "/indicators/mapping-saturation", json=parameters, headers=HEADERS
+            "/indicators/mapping-saturation/data", json=parameters, headers=HEADERS
         )
-        self.run_tests(response, (self.general_schema, self.featurecollection_schema))
+        self.assertEqual(response.status_code, 200)
 
     def test_indicator_topic_data_invalid(self):
         parameters = {
@@ -182,7 +182,7 @@ class TestApiIndicatorIo(unittest.TestCase):
             },
         }
         response = self.client.post(
-            "/indicators/mapping-saturation", json=parameters, headers=HEADERS
+            "/indicators/mapping-saturation/data", json=parameters, headers=HEADERS
         )
         self.assertEqual(response.status_code, 422)
         content = response.json()

--- a/workers/tests/integrationtests/api/test_indicators.py
+++ b/workers/tests/integrationtests/api/test_indicators.py
@@ -144,9 +144,9 @@ def test_minimal_fc(
     assert schema.is_valid(response.json())
 
 
-def test_custom_data(client, bpolys, headers, schema):
+def test_mapping_saturation_data(client, bpolys, headers):
     """Test parameter Topic with custom data attached."""
-    endpoint = ENDPOINT + "mapping-saturation"
+    endpoint = ENDPOINT + "mapping-saturation/data"
     timestamp_objects = [
         datetime(2020, 7, 17, 9, 10, 0) + timedelta(days=1 * x)
         for x in range(DATA.size)
@@ -169,7 +169,7 @@ def test_custom_data(client, bpolys, headers, schema):
         },
     }
     response = client.post(endpoint, json=parameters, headers=headers)
-    assert schema.is_valid(response.json())
+    assert RESPONSE_SCHEMA_JSON.is_valid(response.json())
 
     parameters = {
         "bpolys": bpolys,

--- a/workers/tests/integrationtests/api/test_indicators.py
+++ b/workers/tests/integrationtests/api/test_indicators.py
@@ -4,13 +4,10 @@ Validate the response from requests to the `/indicators` endpoint of the API.
 """
 
 
-from datetime import datetime, timedelta
-
 import pytest
 from schema import Optional, Or, Schema
 
 from tests.integrationtests.utils import oqt_vcr
-from tests.unittests.mapping_saturation.fixtures import VALUES_1 as DATA
 
 ENDPOINT = "/indicators/"
 
@@ -142,46 +139,6 @@ def test_minimal_fc(
     }
     response = client.post(endpoint, json=parameters, headers=headers)
     assert schema.is_valid(response.json())
-
-
-def test_mapping_saturation_data(client, bpolys, headers):
-    """Test parameter Topic with custom data attached."""
-    endpoint = ENDPOINT + "mapping-saturation/data"
-    timestamp_objects = [
-        datetime(2020, 7, 17, 9, 10, 0) + timedelta(days=1 * x)
-        for x in range(DATA.size)
-    ]
-    timestamp_iso_string = [t.strftime("%Y-%m-%dT%H:%M:%S") for t in timestamp_objects]
-    # Data is ohsome API response result for the topic 'building-count' and the bpolys
-    #   of for Heidelberg
-    parameters = {
-        "bpolys": bpolys,
-        "topic": {
-            "key": "foo",
-            "name": "bar",
-            "description": "",
-            "data": {
-                "result": [
-                    {"value": v, "timestamp": t}
-                    for v, t in zip(DATA, timestamp_iso_string)
-                ]
-            },
-        },
-    }
-    response = client.post(endpoint, json=parameters, headers=headers)
-    assert RESPONSE_SCHEMA_JSON.is_valid(response.json())
-
-    parameters = {
-        "bpolys": bpolys,
-        "topic": {
-            "key": "foo",
-            "name": "bar",
-            "description": "",
-            "data": {"result": [{"value": 1.0}]},  # Missing timestamp item
-        },
-    }
-    response = client.post(endpoint, json=parameters)
-    assert response.status_code == 422
 
 
 @oqt_vcr.use_cassette

--- a/workers/tests/integrationtests/api/test_indicators_mapping_saturation_data.py
+++ b/workers/tests/integrationtests/api/test_indicators_mapping_saturation_data.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timedelta
+
+from schema import Optional, Or, Schema
+
+from tests.unittests.mapping_saturation.fixtures import VALUES_1 as DATA
+
+ENDPOINT = "/indicators/"
+
+
+RESPONSE_SCHEMA_JSON = Schema(
+    schema={
+        "apiVersion": str,
+        "attribution": {
+            "url": str,
+            Optional("text"): str,
+        },
+        "results": [
+            {
+                Optional("id"): Or(str, int),
+                "metadata": {
+                    "name": str,
+                    "description": str,
+                },
+                "topic": {
+                    "name": str,
+                    "description": str,
+                },
+                "result": {
+                    "timestampOQT": str,
+                    "timestampOSM": Or(str),
+                    "value": Or(float, str, int, None),
+                    "label": str,
+                    "description": str,
+                    "figure": dict,
+                    Optional("svg"): str,
+                },
+            }
+        ],
+    },
+    name="json",
+    ignore_extra_keys=True,
+)
+
+
+def test_mapping_saturation_data(client, bpolys):
+    """Test parameter Topic with custom data attached."""
+    endpoint = ENDPOINT + "mapping-saturation/data"
+    timestamp_objects = [
+        datetime(2020, 7, 17, 9, 10, 0) + timedelta(days=1 * x)
+        for x in range(DATA.size)
+    ]
+    timestamp_iso_string = [t.strftime("%Y-%m-%dT%H:%M:%S") for t in timestamp_objects]
+    # Data is ohsome API response result for the topic 'building-count' and the bpolys
+    #   of for Heidelberg
+    parameters = {
+        "bpolys": bpolys,
+        "topic": {
+            "key": "foo",
+            "name": "bar",
+            "description": "",
+            "data": {
+                "result": [
+                    {"value": v, "timestamp": t}
+                    for v, t in zip(DATA, timestamp_iso_string)
+                ]
+            },
+        },
+    }
+    response = client.post(endpoint, json=parameters)
+    assert RESPONSE_SCHEMA_JSON.is_valid(response.json())
+
+    parameters = {
+        "bpolys": bpolys,
+        "topic": {
+            "key": "foo",
+            "name": "bar",
+            "description": "",
+            "data": {"result": [{"value": 1.0}]},  # Missing timestamp item
+        },
+    }
+    response = client.post(endpoint, json=parameters)
+    assert response.status_code == 422


### PR DESCRIPTION

### Description
computing mapping-saturation indicator for given data is now a separate endpoint.

### Corresponding issue
Closes #594


### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)