### PR TITLE
various refactoring of oqt.py and definitions.py

### DIFF
--- a/ohsome_quality_analyst/api/api.py
+++ b/ohsome_quality_analyst/api/api.py
@@ -45,12 +45,12 @@ from ohsome_quality_analyst.definitions import (
 )
 from ohsome_quality_analyst.indicators.definitions import (
     IndicatorEnum,
-    get_indicator_definitions,
+    get_indicator_metadata,
 )
 from ohsome_quality_analyst.projects.definitions import (
     ProjectEnum,
     get_project,
-    get_projects,
+    get_project_metadata,
 )
 from ohsome_quality_analyst.quality_dimensions.definitions import (
     QualityDimensionEnum,
@@ -59,12 +59,12 @@ from ohsome_quality_analyst.quality_dimensions.definitions import (
 )
 from ohsome_quality_analyst.reports.definitions import (
     ReportEnum,
-    get_report_definitions,
+    get_report_metadata,
 )
 from ohsome_quality_analyst.topics.definitions import (
     TopicEnum,
-    get_topic_definition,
-    get_topic_definitions,
+    get_topic_preset,
+    get_topic_presets,
 )
 from ohsome_quality_analyst.utils.exceptions import (
     HexCellsNotFoundError,
@@ -375,11 +375,11 @@ async def metadata(project: ProjectEnum = DEFAULT_PROJECT) -> MetadataResponse:
     if project == ProjectEnum.all:
         project = None
     result = {
-        "topics": get_topic_definitions(project=project),
+        "topics": get_topic_presets(project=project),
         "quality_dimensions": get_quality_dimensions(),
-        "projects": get_projects(),
-        "indicators": get_indicator_definitions(project=project),
-        "reports": get_report_definitions(project=project),
+        "projects": get_project_metadata(),
+        "indicators": get_indicator_metadata(project=project),
+        "reports": get_report_metadata(project=project),
     }
     return MetadataResponse(result=result)
 
@@ -397,7 +397,7 @@ async def metadata_topic(
     """Get topics."""
     if project == ProjectEnum.all:
         project = None
-    return TopicMetadataResponse(result=get_topic_definitions(project=project))
+    return TopicMetadataResponse(result=get_topic_presets(project=project))
 
 
 @app.get(
@@ -407,7 +407,7 @@ async def metadata_topic(
 )
 async def metadata_topic_by_key(key: TopicEnum) -> TopicMetadataResponse:
     """Get topic by key."""
-    return TopicMetadataResponse(result={key.value: get_topic_definition(key.value)})
+    return TopicMetadataResponse(result={key.value: get_topic_preset(key.value)})
 
 
 @app.get(
@@ -438,7 +438,7 @@ async def metadata_quality_dimension_by_key(
 )
 async def metadata_projects() -> ProjectMetadataResponse:
     """Get projects."""
-    return ProjectMetadataResponse(result=get_projects())
+    return ProjectMetadataResponse(result=get_project_metadata())
 
 
 @app.get(
@@ -468,7 +468,7 @@ async def metadata_indicators(
     """Get metadata of all indicators."""
     if project == ProjectEnum.all:
         project = None
-    return IndicatorMetadataResponse(result=get_indicator_definitions(project=project))
+    return IndicatorMetadataResponse(result=get_indicator_metadata(project=project))
 
 
 @app.get(
@@ -501,7 +501,7 @@ async def metadata_reports(
     """Get metadata of all indicators."""
     if project == ProjectEnum.all:
         project = None
-    return ReportMetadataResponse(result=get_report_definitions(project=project))
+    return ReportMetadataResponse(result=get_report_metadata(project=project))
 
 
 @app.get(

--- a/ohsome_quality_analyst/api/api.py
+++ b/ohsome_quality_analyst/api/api.py
@@ -27,11 +27,8 @@ from ohsome_quality_analyst import (
 )
 from ohsome_quality_analyst.api.request_models import (
     IndicatorDataRequest,
-    IndicatorEnum,
     IndicatorRequest,
-    ReportEnum,
     ReportRequest,
-    TopicEnum,
 )
 from ohsome_quality_analyst.api.response_models import (
     IndicatorMetadataResponse,
@@ -50,6 +47,7 @@ from ohsome_quality_analyst.definitions import (
     get_topic_definition,
     get_topic_definitions,
 )
+from ohsome_quality_analyst.indicators.definitions import IndicatorEnum
 from ohsome_quality_analyst.projects.definitions import (
     ProjectEnum,
     get_project,
@@ -60,6 +58,8 @@ from ohsome_quality_analyst.quality_dimensions.definitions import (
     get_quality_dimension,
     get_quality_dimensions,
 )
+from ohsome_quality_analyst.reports.definitions import ReportEnum
+from ohsome_quality_analyst.topics.definitions import TopicEnum
 from ohsome_quality_analyst.utils.exceptions import (
     HexCellsNotFoundError,
     OhsomeApiError,

--- a/ohsome_quality_analyst/api/api.py
+++ b/ohsome_quality_analyst/api/api.py
@@ -262,7 +262,7 @@ def empty_api_response() -> dict:
 @app.post("/indicators/mapping-saturation/data", include_in_schema=False)
 async def post_indicator_ms(parameters: IndicatorDataRequest) -> CustomJSONResponse:
     """Legacy support for computing the Mapping Saturation indicator for given data."""
-    geojson_object = await oqt.create_indicator_as_geojson(
+    geojson_object = await oqt.create_indicator(
         parameters,
         key="mapping-saturation",
     )
@@ -302,7 +302,7 @@ async def post_indicator(
     """Request an Indicator for an AOI defined by OQT or a custom AOI."""
     if isinstance(parameters, IndicatorRequest):
         validate_indicator_topic_combination(key.value, parameters.topic_key.value)
-    geojson_object = await oqt.create_indicator_as_geojson(parameters, key=key.value)
+    geojson_object = await oqt.create_indicator(parameters, key=key.value)
     response = empty_api_response()
     response["attribution"]["text"] = get_class_from_key(
         class_type="indicator",
@@ -340,7 +340,7 @@ async def post_report(
     parameters: ReportRequest,
 ) -> CustomJSONResponse:
     """Request a Report for an AOI defined by OQT or a custom AOI."""
-    geojson_object = await oqt.create_report_as_geojson(parameters, key=key.value)
+    geojson_object = await oqt.create_report(parameters, key=key.value)
     response = empty_api_response()
     response["attribution"]["text"] = get_class_from_key(
         class_type="report",

--- a/ohsome_quality_analyst/api/api.py
+++ b/ohsome_quality_analyst/api/api.py
@@ -41,13 +41,12 @@ from ohsome_quality_analyst.api.response_models import (
 from ohsome_quality_analyst.config import configure_logging
 from ohsome_quality_analyst.definitions import (
     ATTRIBUTION_URL,
-    get_indicator_definitions,
     get_metadata,
-    get_report_definitions,
-    get_topic_definition,
-    get_topic_definitions,
 )
-from ohsome_quality_analyst.indicators.definitions import IndicatorEnum
+from ohsome_quality_analyst.indicators.definitions import (
+    IndicatorEnum,
+    get_indicator_definitions,
+)
 from ohsome_quality_analyst.projects.definitions import (
     ProjectEnum,
     get_project,
@@ -58,8 +57,15 @@ from ohsome_quality_analyst.quality_dimensions.definitions import (
     get_quality_dimension,
     get_quality_dimensions,
 )
-from ohsome_quality_analyst.reports.definitions import ReportEnum
-from ohsome_quality_analyst.topics.definitions import TopicEnum
+from ohsome_quality_analyst.reports.definitions import (
+    ReportEnum,
+    get_report_definitions,
+)
+from ohsome_quality_analyst.topics.definitions import (
+    TopicEnum,
+    get_topic_definition,
+    get_topic_definitions,
+)
 from ohsome_quality_analyst.utils.exceptions import (
     HexCellsNotFoundError,
     OhsomeApiError,

--- a/ohsome_quality_analyst/api/request_models.py
+++ b/ohsome_quality_analyst/api/request_models.py
@@ -1,27 +1,14 @@
 import json
-from enum import Enum
 
 import geojson
 import pydantic
 from geojson import FeatureCollection
 from pydantic import BaseModel
 
-from ohsome_quality_analyst.definitions import (
-    get_dataset_names,
-    get_fid_fields,
-    get_indicator_names,
-    get_report_names,
-    get_topic_keys,
-)
+from ohsome_quality_analyst.topics.definitions import TopicEnum
 from ohsome_quality_analyst.topics.models import TopicData
 from ohsome_quality_analyst.utils.helper import snake_to_lower_camel
 from ohsome_quality_analyst.utils.validators import validate_geojson
-
-IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_names()})
-ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})
-TopicEnum = Enum("TopicEnum", {name: name for name in get_topic_keys()})
-DatasetEnum = Enum("DatasetNames", {name: name for name in get_dataset_names()})
-FidFieldEnum = Enum("FidFieldEnum", {name: name for name in get_fid_fields()})
 
 
 class BaseBpolys(BaseModel):

--- a/ohsome_quality_analyst/api/response_models.py
+++ b/ohsome_quality_analyst/api/response_models.py
@@ -1,18 +1,16 @@
 from pydantic import BaseModel, validator
 
 from ohsome_quality_analyst import __version__
-from ohsome_quality_analyst.api.request_models import (
-    IndicatorEnum,
-    ReportEnum,
-    TopicEnum,
-)
 from ohsome_quality_analyst.definitions import ATTRIBUTION_URL
+from ohsome_quality_analyst.indicators.definitions import IndicatorEnum
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.projects.definitions import ProjectEnum
 from ohsome_quality_analyst.projects.models import Project
 from ohsome_quality_analyst.quality_dimensions.definitions import QualityDimensionEnum
 from ohsome_quality_analyst.quality_dimensions.models import QualityDimension
+from ohsome_quality_analyst.reports.definitions import ReportEnum
 from ohsome_quality_analyst.reports.models import ReportMetadata
+from ohsome_quality_analyst.topics.definitions import TopicEnum
 from ohsome_quality_analyst.topics.models import TopicDefinition
 from ohsome_quality_analyst.utils.helper import snake_to_lower_camel
 

--- a/ohsome_quality_analyst/definitions.py
+++ b/ohsome_quality_analyst/definitions.py
@@ -7,14 +7,12 @@ from typing import Iterable, Literal
 
 import yaml
 
-from ohsome_quality_analyst.config import get_config_value
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.reports.models import ReportMetadata
 from ohsome_quality_analyst.topics.definitions import load_topic_presets
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 from ohsome_quality_analyst.utils.helper import (
     camel_to_hyphen,
-    flatten_sequence,
     get_module_dir,
 )
 
@@ -131,10 +129,6 @@ def get_project_keys() -> Iterable[str]:
     return set(t.project for t in load_topic_presets().values())
 
 
-def get_dataset_names() -> list[str]:
-    return list(get_config_value("datasets").keys())
-
-
 def get_raster_dataset_names() -> list[str]:
     return [r.name for r in RASTER_DATASETS]
 
@@ -155,10 +149,6 @@ def get_raster_dataset(name: str) -> RasterDataset:
         return next(filter(lambda r: r.name == name, RASTER_DATASETS))
     except StopIteration as e:
         raise RasterDatasetUndefinedError(name) from e
-
-
-def get_fid_fields() -> list[str]:
-    return flatten_sequence(get_config_value("datasets").values())
 
 
 def get_attribution(data_keys: list) -> str:

--- a/ohsome_quality_analyst/definitions.py
+++ b/ohsome_quality_analyst/definitions.py
@@ -1,7 +1,6 @@
 """Global Variables and Functions."""
 import glob
 import logging
-from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Iterable, Literal
 
@@ -10,54 +9,9 @@ import yaml
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.reports.models import ReportMetadata
 from ohsome_quality_analyst.topics.definitions import load_topic_presets
-from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 from ohsome_quality_analyst.utils.helper import (
     camel_to_hyphen,
     get_module_dir,
-)
-
-
-@dataclass(frozen=True)
-class RasterDataset:
-    """Raster datasets available on disk.
-
-    Args:
-        name: Name of raster
-        filename: Filename of raster on disk
-        crs: An authority string (i.e. `EPSG:4326` or `ESRI:54009`)
-    """
-
-    name: str
-    filename: str
-    crs: str
-    nodata: int | None
-
-
-RASTER_DATASETS = (
-    RasterDataset(
-        "GHS_BUILT_R2018A",
-        "GHS_BUILT_LDS2014_GLOBE_R2018A_54009_1K_V2_0.tif",
-        "ESRI:54009",
-        -200,
-    ),
-    RasterDataset(
-        "GHS_POP_R2019A",
-        "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
-        "ESRI:54009",
-        -200,
-    ),
-    RasterDataset(
-        "GHS_SMOD_R2019A",
-        "GHS_SMOD_POP2015_GLOBE_R2019A_54009_1K_V2_0.tif",
-        "ESRI:54009",
-        -200,
-    ),
-    RasterDataset(
-        "VNL",
-        "VNL_v2_npp_2020_global_vcmslcfg_c202102150000.average_masked.tif",
-        "EPSG:4326",
-        -999,
-    ),
 )
 
 ATTRIBUTION_TEXTS = MappingProxyType(
@@ -127,28 +81,6 @@ def get_metadata(
 # TODO: duplicate of func with the same name in projects/definition.py ?
 def get_project_keys() -> Iterable[str]:
     return set(t.project for t in load_topic_presets().values())
-
-
-def get_raster_dataset_names() -> list[str]:
-    return [r.name for r in RASTER_DATASETS]
-
-
-def get_raster_dataset(name: str) -> RasterDataset:
-    """Get a instance of the `RasterDataset` class by the raster name.
-
-    Args:
-        name: Name of the raster as defined by `RASTER_DATASETS`.
-
-    Returns
-        An instance of the `RasterDataset` class with matching name.
-
-    Raises:
-        RasterDatasetUndefinedError: If no matching `RasterDataset` class is found.
-    """
-    try:
-        return next(filter(lambda r: r.name == name, RASTER_DATASETS))
-    except StopIteration as e:
-        raise RasterDatasetUndefinedError(name) from e
 
 
 def get_attribution(data_keys: list) -> str:

--- a/ohsome_quality_analyst/definitions.py
+++ b/ohsome_quality_analyst/definitions.py
@@ -10,7 +10,7 @@ import yaml
 from ohsome_quality_analyst.config import get_config_value
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.reports.models import ReportMetadata
-from ohsome_quality_analyst.topics.definitions import load_topic_definitions
+from ohsome_quality_analyst.topics.definitions import load_topic_presets
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 from ohsome_quality_analyst.utils.helper import (
     camel_to_hyphen,
@@ -128,7 +128,7 @@ def get_metadata(
 
 # TODO: duplicate of func with the same name in projects/definition.py ?
 def get_project_keys() -> Iterable[str]:
-    return set(t.project for t in load_topic_definitions().values())
+    return set(t.project for t in load_topic_presets().values())
 
 
 def get_dataset_names() -> list[str]:

--- a/ohsome_quality_analyst/indicators/building_completeness/indicator.py
+++ b/ohsome_quality_analyst/indicators/building_completeness/indicator.py
@@ -10,10 +10,10 @@ from building_completeness_model import Predictor, Processor
 from geojson import Feature, FeatureCollection
 
 import ohsome_quality_analyst.geodatabase.client as db_client
-from ohsome_quality_analyst.definitions import get_raster_dataset
 from ohsome_quality_analyst.indicators.base import BaseIndicator
 from ohsome_quality_analyst.ohsome import client as ohsome_client
 from ohsome_quality_analyst.raster import client as raster_client
+from ohsome_quality_analyst.raster.definitions import get_raster_dataset
 from ohsome_quality_analyst.topics.models import BaseTopic as Topic
 from ohsome_quality_analyst.utils.exceptions import HexCellsNotFoundError
 

--- a/ohsome_quality_analyst/indicators/definitions.py
+++ b/ohsome_quality_analyst/indicators/definitions.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+from ohsome_quality_analyst.definitions import get_indicator_names
+
+IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_names()})

--- a/ohsome_quality_analyst/indicators/definitions.py
+++ b/ohsome_quality_analyst/indicators/definitions.py
@@ -1,5 +1,29 @@
 from enum import Enum
 
-from ohsome_quality_analyst.definitions import get_indicator_names
+from ohsome_quality_analyst.definitions import load_metadata
+from ohsome_quality_analyst.indicators.models import IndicatorMetadata
+from ohsome_quality_analyst.projects.definitions import ProjectEnum
+from ohsome_quality_analyst.topics.definitions import load_topic_definitions
+
+
+def get_indicator_names() -> list[str]:
+    return list(load_metadata("indicators").keys())
+
 
 IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_names()})
+
+
+def get_indicator_definitions(
+    project: ProjectEnum = None,
+) -> dict[str, IndicatorMetadata]:
+    indicators = load_metadata("indicators")
+    if project is not None:
+        return {k: v for k, v in indicators.items() if project in v.projects}
+    else:
+        return indicators
+
+
+def get_valid_indicators(topic_key: str) -> tuple:
+    """Get valid Indicator/Topic combination of a Topic."""
+    td = load_topic_definitions()
+    return tuple(td[topic_key].indicators)

--- a/ohsome_quality_analyst/indicators/definitions.py
+++ b/ohsome_quality_analyst/indicators/definitions.py
@@ -3,19 +3,14 @@ from enum import Enum
 from ohsome_quality_analyst.definitions import load_metadata
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.projects.definitions import ProjectEnum
-from ohsome_quality_analyst.topics.definitions import load_topic_definitions
+from ohsome_quality_analyst.topics.definitions import load_topic_presets
 
 
-def get_indicator_names() -> list[str]:
+def get_indicator_keys() -> list[str]:
     return list(load_metadata("indicators").keys())
 
 
-IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_names()})
-
-
-def get_indicator_definitions(
-    project: ProjectEnum = None,
-) -> dict[str, IndicatorMetadata]:
+def get_indicator_metadata(project: ProjectEnum = None) -> dict[str, IndicatorMetadata]:
     indicators = load_metadata("indicators")
     if project is not None:
         return {k: v for k, v in indicators.items() if project in v.projects}
@@ -25,5 +20,8 @@ def get_indicator_definitions(
 
 def get_valid_indicators(topic_key: str) -> tuple:
     """Get valid Indicator/Topic combination of a Topic."""
-    td = load_topic_definitions()
+    td = load_topic_presets()
     return tuple(td[topic_key].indicators)
+
+
+IndicatorEnum = Enum("IndicatorEnum", {name: name for name in get_indicator_keys()})

--- a/ohsome_quality_analyst/oqt.py
+++ b/ohsome_quality_analyst/oqt.py
@@ -12,7 +12,7 @@ from ohsome_quality_analyst.api.request_models import (
 )
 from ohsome_quality_analyst.indicators.base import BaseIndicator as Indicator
 from ohsome_quality_analyst.reports.base import BaseReport as Report
-from ohsome_quality_analyst.topics.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_preset
 from ohsome_quality_analyst.utils.helper import get_class_from_key, loads_geojson
 from ohsome_quality_analyst.utils.helper_asyncio import gather_with_semaphore
 from ohsome_quality_analyst.utils.validators import validate_area
@@ -30,7 +30,7 @@ async def create_indicator(
     if isinstance(parameters, IndicatorDataRequest):
         topic = parameters.topic
     else:
-        topic = get_topic_definition(parameters.topic_key.value)
+        topic = get_topic_preset(parameters.topic_key.value)
     include_data = parameters.include_data
 
     tasks: list[Coroutine] = []
@@ -102,7 +102,7 @@ async def _create_report(key: str, feature: Feature) -> Report:
 
     tasks: list[Coroutine] = []
     for indicator_key, topic_key in report.indicator_topic:
-        topic = get_topic_definition(topic_key)
+        topic = get_topic_preset(topic_key)
         tasks.append(_create_indicator(indicator_key, feature, topic))
 
     report.indicators = await gather_with_semaphore(tasks)

--- a/ohsome_quality_analyst/oqt.py
+++ b/ohsome_quality_analyst/oqt.py
@@ -10,9 +10,9 @@ from ohsome_quality_analyst.api.request_models import (
     IndicatorRequest,
     ReportRequest,
 )
-from ohsome_quality_analyst.definitions import get_topic_definition
 from ohsome_quality_analyst.indicators.base import BaseIndicator as Indicator
 from ohsome_quality_analyst.reports.base import BaseReport as Report
+from ohsome_quality_analyst.topics.definitions import get_topic_definition
 from ohsome_quality_analyst.utils.helper import get_class_from_key, loads_geojson
 from ohsome_quality_analyst.utils.helper_asyncio import gather_with_semaphore
 from ohsome_quality_analyst.utils.validators import validate_area

--- a/ohsome_quality_analyst/projects/definitions.py
+++ b/ohsome_quality_analyst/projects/definitions.py
@@ -8,6 +8,10 @@ from ohsome_quality_analyst.projects.models import Project
 from ohsome_quality_analyst.utils.helper import get_module_dir
 
 
+def get_project_keys() -> list[str]:
+    return [str(t) for t in load_projects().keys()]
+
+
 def load_projects() -> dict[str, Project]:
     """Read definitions of projects.
 
@@ -24,23 +28,19 @@ def load_projects() -> dict[str, Project]:
     return projects
 
 
-def get_projects() -> dict[str, Project]:
+def get_project_metadata() -> dict[str, Project]:
     projects = load_projects()
     return projects
 
 
 def get_project(project_key: str) -> Project:
-    projects = get_projects()
+    projects = get_project_metadata()
     try:
         return projects[project_key]
     except KeyError as error:
         raise KeyError(
             "Invalid project key. Valid project keys are: " + str(projects.keys())
         ) from error
-
-
-def get_project_keys() -> list[str]:
-    return [str(t) for t in load_projects().keys()]
 
 
 ProjectEnum = Enum("ProjectEnum", {key: key for key in get_project_keys() + ["all"]})

--- a/ohsome_quality_analyst/raster/client.py
+++ b/ohsome_quality_analyst/raster/client.py
@@ -8,7 +8,7 @@ from pyproj import Transformer
 from rasterstats import zonal_stats
 
 from ohsome_quality_analyst.config import get_config_value
-from ohsome_quality_analyst.definitions import RasterDataset
+from ohsome_quality_analyst.raster.definitions import RasterDataset
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetNotFoundError
 
 

--- a/ohsome_quality_analyst/raster/definitions.py
+++ b/ohsome_quality_analyst/raster/definitions.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
+
+
+@dataclass(frozen=True)
+class RasterDataset:
+    """Raster datasets available on disk.
+
+    Args:
+        name: Name of raster
+        filename: Filename of raster on disk
+        crs: An authority string (i.e. `EPSG:4326` or `ESRI:54009`)
+    """
+
+    name: str
+    filename: str
+    crs: str
+    nodata: int | None
+
+
+RASTER_DATASETS = (
+    RasterDataset(
+        "GHS_BUILT_R2018A",
+        "GHS_BUILT_LDS2014_GLOBE_R2018A_54009_1K_V2_0.tif",
+        "ESRI:54009",
+        -200,
+    ),
+    RasterDataset(
+        "GHS_POP_R2019A",
+        "GHS_POP_E2015_GLOBE_R2019A_54009_1K_V1_0.tif",
+        "ESRI:54009",
+        -200,
+    ),
+    RasterDataset(
+        "GHS_SMOD_R2019A",
+        "GHS_SMOD_POP2015_GLOBE_R2019A_54009_1K_V2_0.tif",
+        "ESRI:54009",
+        -200,
+    ),
+    RasterDataset(
+        "VNL",
+        "VNL_v2_npp_2020_global_vcmslcfg_c202102150000.average_masked.tif",
+        "EPSG:4326",
+        -999,
+    ),
+)
+
+
+def get_raster_dataset_names() -> list[str]:
+    return [r.name for r in RASTER_DATASETS]
+
+
+def get_raster_dataset(name: str) -> RasterDataset:
+    """Get a instance of the `RasterDataset` class by the raster name.
+
+    Args:
+        name: Name of the raster as defined by `RASTER_DATASETS`.
+
+    Returns
+        An instance of the `RasterDataset` class with matching name.
+
+    Raises:
+        RasterDatasetUndefinedError: If no matching `RasterDataset` class is found.
+    """
+    try:
+        return next(filter(lambda r: r.name == name, RASTER_DATASETS))
+    except StopIteration as e:
+        raise RasterDatasetUndefinedError(name) from e

--- a/ohsome_quality_analyst/reports/definitions.py
+++ b/ohsome_quality_analyst/reports/definitions.py
@@ -5,14 +5,11 @@ from ohsome_quality_analyst.projects.definitions import ProjectEnum
 from ohsome_quality_analyst.reports.models import ReportMetadata
 
 
-def get_report_names() -> list[str]:
+def get_report_keys() -> list[str]:
     return list(load_metadata("reports").keys())
 
 
-ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})
-
-
-def get_report_definitions(project: ProjectEnum = None) -> dict[str, ReportMetadata]:
+def get_report_metadata(project: ProjectEnum = None) -> dict[str, ReportMetadata]:
     reports = load_metadata("reports")
     if project is not None:
         return {k: v for k, v in reports.items() if project in v.projects}
@@ -20,9 +17,4 @@ def get_report_definitions(project: ProjectEnum = None) -> dict[str, ReportMetad
         return reports
 
 
-def get_report_classes() -> dict:
-    """Map report name to corresponding class."""
-    raise NotImplementedError(
-        "Use utils.definitions.load_indicator_metadata() and"
-        + "utils.helper.name_to_class() instead"
-    )
+ReportEnum = Enum("ReportEnum", {name: name for name in get_report_keys()})

--- a/ohsome_quality_analyst/reports/definitions.py
+++ b/ohsome_quality_analyst/reports/definitions.py
@@ -1,5 +1,28 @@
 from enum import Enum
 
-from ohsome_quality_analyst.definitions import get_report_names
+from ohsome_quality_analyst.definitions import load_metadata
+from ohsome_quality_analyst.projects.definitions import ProjectEnum
+from ohsome_quality_analyst.reports.models import ReportMetadata
+
+
+def get_report_names() -> list[str]:
+    return list(load_metadata("reports").keys())
+
 
 ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})
+
+
+def get_report_definitions(project: ProjectEnum = None) -> dict[str, ReportMetadata]:
+    reports = load_metadata("reports")
+    if project is not None:
+        return {k: v for k, v in reports.items() if project in v.projects}
+    else:
+        return reports
+
+
+def get_report_classes() -> dict:
+    """Map report name to corresponding class."""
+    raise NotImplementedError(
+        "Use utils.definitions.load_indicator_metadata() and"
+        + "utils.helper.name_to_class() instead"
+    )

--- a/ohsome_quality_analyst/reports/definitions.py
+++ b/ohsome_quality_analyst/reports/definitions.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+from ohsome_quality_analyst.definitions import get_report_names
+
+ReportEnum = Enum("ReportEnum", {name: name for name in get_report_names()})

--- a/ohsome_quality_analyst/topics/definitions.py
+++ b/ohsome_quality_analyst/topics/definitions.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+from ohsome_quality_analyst.definitions import get_topic_keys
+
+TopicEnum = Enum("TopicEnum", {name: name for name in get_topic_keys()})

--- a/ohsome_quality_analyst/topics/definitions.py
+++ b/ohsome_quality_analyst/topics/definitions.py
@@ -1,5 +1,58 @@
+import os
 from enum import Enum
 
-from ohsome_quality_analyst.definitions import get_topic_keys
+import yaml
+
+from ohsome_quality_analyst.projects.definitions import ProjectEnum
+from ohsome_quality_analyst.topics.models import TopicDefinition
+from ohsome_quality_analyst.utils.helper import get_module_dir
+
+
+def get_topic_keys() -> list[str]:
+    return [str(t) for t in load_topic_definitions().keys()]
+
+
+def load_topic_definitions() -> dict[str, TopicDefinition]:
+    """Read ohsome API parameters of all topic from YAML file.
+
+    Returns:
+        A dict with all topics included.
+    """
+    directory = get_module_dir("ohsome_quality_analyst.topics")
+    file = os.path.join(directory, "presets.yaml")
+    with open(file, "r") as f:
+        raw = yaml.safe_load(f)
+    topics = {}
+    for k, v in raw.items():
+        v["filter"] = v.pop("filter")
+        v["key"] = k
+        topics[k] = TopicDefinition(**v)
+    return topics
+
+
+def get_topic_definitions(project: ProjectEnum = None) -> dict[str, TopicDefinition]:
+    topics = load_topic_definitions()
+    if project is not None:
+        return {k: v for k, v in topics.items() if project in v.projects}
+    else:
+        return topics
+
+
+def get_topic_definition(topic_key: str) -> TopicDefinition:
+    """Get ohsome API parameters of a single topic based on topic key."""
+    topics = load_topic_definitions()
+    try:
+        return topics[topic_key]
+    except KeyError as error:
+        raise KeyError(
+            "Invalid topic key. Valid topic keys are: " + str(topics.keys())
+        ) from error
+
+
+def get_valid_topics(indicator_name: str) -> tuple:
+    """Get valid Indicator/Topic combination of an Indicator."""
+    td = load_topic_definitions()
+    return tuple(topic for topic in td if indicator_name in td[topic].indicators)
+
 
 TopicEnum = Enum("TopicEnum", {name: name for name in get_topic_keys()})

--- a/ohsome_quality_analyst/topics/definitions.py
+++ b/ohsome_quality_analyst/topics/definitions.py
@@ -9,10 +9,10 @@ from ohsome_quality_analyst.utils.helper import get_module_dir
 
 
 def get_topic_keys() -> list[str]:
-    return [str(t) for t in load_topic_definitions().keys()]
+    return [str(t) for t in load_topic_presets().keys()]
 
 
-def load_topic_definitions() -> dict[str, TopicDefinition]:
+def load_topic_presets() -> dict[str, TopicDefinition]:
     """Read ohsome API parameters of all topic from YAML file.
 
     Returns:
@@ -30,17 +30,17 @@ def load_topic_definitions() -> dict[str, TopicDefinition]:
     return topics
 
 
-def get_topic_definitions(project: ProjectEnum = None) -> dict[str, TopicDefinition]:
-    topics = load_topic_definitions()
+def get_topic_presets(project: ProjectEnum = None) -> dict[str, TopicDefinition]:
+    topics = load_topic_presets()
     if project is not None:
         return {k: v for k, v in topics.items() if project in v.projects}
     else:
         return topics
 
 
-def get_topic_definition(topic_key: str) -> TopicDefinition:
+def get_topic_preset(topic_key: str) -> TopicDefinition:
     """Get ohsome API parameters of a single topic based on topic key."""
-    topics = load_topic_definitions()
+    topics = load_topic_presets()
     try:
         return topics[topic_key]
     except KeyError as error:
@@ -51,7 +51,7 @@ def get_topic_definition(topic_key: str) -> TopicDefinition:
 
 def get_valid_topics(indicator_name: str) -> tuple:
     """Get valid Indicator/Topic combination of an Indicator."""
-    td = load_topic_definitions()
+    td = load_topic_presets()
     return tuple(topic for topic in td if indicator_name in td[topic].indicators)
 
 

--- a/ohsome_quality_analyst/utils/validators.py
+++ b/ohsome_quality_analyst/utils/validators.py
@@ -1,7 +1,7 @@
 from geojson import Feature, FeatureCollection, GeoJSON, MultiPolygon, Polygon
 
 from ohsome_quality_analyst.config import get_config_value
-from ohsome_quality_analyst.definitions import get_valid_indicators
+from ohsome_quality_analyst.indicators.definitions import get_valid_indicators
 from ohsome_quality_analyst.utils.exceptions import (
     GeoJSONError,
     GeoJSONGeometryTypeError,

--- a/scripts/run_mapping_saturation_models.py
+++ b/scripts/run_mapping_saturation_models.py
@@ -11,8 +11,8 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 
 import ohsome_quality_analyst.geodatabase.client as db_client
 import ohsome_quality_analyst.ohsome.client as ohsome_client
-from ohsome_quality_analyst.definitions import get_topic_definition
 from ohsome_quality_analyst.indicators.mapping_saturation import models
+from ohsome_quality_analyst.topics.definitions import get_topic_definition
 
 
 def plot(xdata, ydata, model_list):

--- a/scripts/run_mapping_saturation_models.py
+++ b/scripts/run_mapping_saturation_models.py
@@ -12,7 +12,7 @@ from rpy2.rinterface_lib.embedded import RRuntimeError
 import ohsome_quality_analyst.geodatabase.client as db_client
 import ohsome_quality_analyst.ohsome.client as ohsome_client
 from ohsome_quality_analyst.indicators.mapping_saturation import models
-from ohsome_quality_analyst.topics.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_preset
 
 
 def plot(xdata, ydata, model_list):
@@ -55,7 +55,7 @@ async def query_ohsome_api(features, topics) -> list:
 def get_topics(topic_keys) -> list:
     topics = []
     for topic_key in topic_keys:
-        topics.append(get_topic_definition(topic_key))
+        topics.append(get_topic_preset(topic_key))
     return topics
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,7 @@ from geojson import Feature, FeatureCollection, Polygon
 
 from ohsome_quality_analyst.definitions import (
     get_metadata,
-    get_topic_definition,
     load_metadata,
-    load_topic_definitions,
 )
 from ohsome_quality_analyst.indicators.models import IndicatorMetadata
 from ohsome_quality_analyst.projects.definitions import get_project, load_projects
@@ -20,6 +18,10 @@ from ohsome_quality_analyst.quality_dimensions.definitions import (
 )
 from ohsome_quality_analyst.quality_dimensions.models import QualityDimension
 from ohsome_quality_analyst.reports.models import ReportMetadata
+from ohsome_quality_analyst.topics.definitions import (
+    get_topic_definition,
+    load_topic_definitions,
+)
 
 # from ohsome_quality_analyst.indicators import MappingSaturation
 # from ohsome_quality_analyst.indicators.models import BaseIndicator as Indicator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,8 @@ from ohsome_quality_analyst.quality_dimensions.definitions import (
 from ohsome_quality_analyst.quality_dimensions.models import QualityDimension
 from ohsome_quality_analyst.reports.models import ReportMetadata
 from ohsome_quality_analyst.topics.definitions import (
-    get_topic_definition,
-    load_topic_definitions,
+    get_topic_preset,
+    load_topic_presets,
 )
 
 # from ohsome_quality_analyst.indicators import MappingSaturation
@@ -47,12 +47,12 @@ def topic_key_building_count() -> str:
 
 @pytest.fixture(scope="class")
 def topic_minimal(topic_key_minimal) -> TopicDefinition:
-    return get_topic_definition(topic_key_minimal)
+    return get_topic_preset(topic_key_minimal)
 
 
 @pytest.fixture(scope="class")
 def topic_building_count(topic_key_building_count) -> TopicDefinition:
-    return get_topic_definition(topic_key_building_count)
+    return get_topic_preset(topic_key_building_count)
 
 
 @pytest.fixture(scope="class")
@@ -65,7 +65,7 @@ def metadata_topic_building_count(
 
 @pytest.fixture()
 def topic_definitions() -> dict[str, TopicDefinition]:
-    return load_topic_definitions()
+    return load_topic_presets()
 
 
 @pytest.fixture(scope="class")

--- a/tests/integrationtests/api/test_metadata.py
+++ b/tests/integrationtests/api/test_metadata.py
@@ -1,8 +1,6 @@
-from ohsome_quality_analyst.api.request_models import (
-    IndicatorEnum,
-    ReportEnum,
-    TopicEnum,
-)
+from ohsome_quality_analyst.indicators.definitions import IndicatorEnum
+from ohsome_quality_analyst.reports.definitions import ReportEnum
+from ohsome_quality_analyst.topics.definitions import TopicEnum
 
 
 def test_metadata(

--- a/tests/integrationtests/api/test_metadata_indicators.py
+++ b/tests/integrationtests/api/test_metadata_indicators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ohsome_quality_analyst.api.request_models import IndicatorEnum
+from ohsome_quality_analyst.indicators.definitions import IndicatorEnum
 
 
 def test(client, response_template, metadata_indicator_mapping_saturation):

--- a/tests/integrationtests/api/test_metadata_reports.py
+++ b/tests/integrationtests/api/test_metadata_reports.py
@@ -1,4 +1,4 @@
-from ohsome_quality_analyst.api.request_models import ReportEnum
+from ohsome_quality_analyst.reports.definitions import ReportEnum
 
 
 def test(client, response_template, metadata_report_multilevel_mapping_saturation):

--- a/tests/integrationtests/api/test_metadata_topics.py
+++ b/tests/integrationtests/api/test_metadata_topics.py
@@ -1,4 +1,4 @@
-from ohsome_quality_analyst.api.request_models import TopicEnum
+from ohsome_quality_analyst.topics.definitions import TopicEnum
 
 
 def test_metadata_topic(client, response_template, metadata_topic_building_count):

--- a/tests/integrationtests/indicators/test_density.py
+++ b/tests/integrationtests/indicators/test_density.py
@@ -6,14 +6,14 @@ import plotly.io as pio
 import pytest
 
 from ohsome_quality_analyst.indicators.density.indicator import Density
-from ohsome_quality_analyst.topics.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_preset
 from ohsome_quality_analyst.topics.models import TopicDefinition
 from tests.integrationtests.utils import oqt_vcr
 
 
 @pytest.fixture(scope="class")
 def topic_poi() -> TopicDefinition:
-    return get_topic_definition("poi")
+    return get_topic_preset("poi")
 
 
 class TestPreprocess:

--- a/tests/integrationtests/indicators/test_density.py
+++ b/tests/integrationtests/indicators/test_density.py
@@ -5,8 +5,8 @@ import plotly.graph_objects as pgo
 import plotly.io as pio
 import pytest
 
-from ohsome_quality_analyst.definitions import get_topic_definition
 from ohsome_quality_analyst.indicators.density.indicator import Density
+from ohsome_quality_analyst.topics.definitions import get_topic_definition
 from ohsome_quality_analyst.topics.models import TopicDefinition
 from tests.integrationtests.utils import oqt_vcr
 

--- a/tests/integrationtests/test_oqt.py
+++ b/tests/integrationtests/test_oqt.py
@@ -28,7 +28,7 @@ from tests.integrationtests.utils import oqt_vcr
 def test_create_indicator(feature, indicator, topic, request):
     """Minimal viable request for a single bpoly."""
     topic = request.getfixturevalue(topic)
-    indicator = asyncio.run(oqt.create_indicator(indicator, feature, topic))
+    indicator = asyncio.run(oqt._create_indicator(indicator, feature, topic))
     assert indicator.result.label is not None
     assert indicator.result.value is not None
     assert indicator.result.description is not None
@@ -37,7 +37,7 @@ def test_create_indicator(feature, indicator, topic, request):
 
 @oqt_vcr.use_cassette
 def test_create_report(feature):
-    report = asyncio.run(oqt.create_report("minimal", feature))
+    report = asyncio.run(oqt._create_report("minimal", feature))
     assert report.result.label is not None
     assert report.result.class_ is not None
     assert report.result.description is not None
@@ -64,9 +64,7 @@ class TestOqt(unittest.TestCase):
             bpolys=self.feature,
         )
         with self.assertRaises(ValueError):
-            asyncio.run(
-                oqt.create_indicator_as_geojson(parameters, key=self.indicator_name)
-            )
+            asyncio.run(oqt.create_indicator(parameters, key=self.indicator_name))
 
     @mock.patch.dict("os.environ", {"OQT_GEOM_SIZE_LIMIT": "1"}, clear=True)
     @oqt_vcr.use_cassette
@@ -79,9 +77,7 @@ class TestOqt(unittest.TestCase):
             topic="building-count",
             bpolys=self.feature,
         )
-        asyncio.run(
-            oqt.create_indicator_as_geojson(parameters, key="mapping-saturation")
-        )
+        asyncio.run(oqt.create_indicator(parameters, key="mapping-saturation"))
 
     @mock.patch.dict("os.environ", {"OQT_GEOM_SIZE_LIMIT": "1"}, clear=True)
     @oqt_vcr.use_cassette
@@ -106,9 +102,7 @@ class TestOqt(unittest.TestCase):
                 },
             },
         )
-        asyncio.run(
-            oqt.create_indicator_as_geojson(parameters, key="mapping-saturation")
-        )
+        asyncio.run(oqt.create_indicator(parameters, key="mapping-saturation"))
 
 
 if __name__ == "__main__":

--- a/tests/integrationtests/test_oqt_geojson_io.py
+++ b/tests/integrationtests/test_oqt_geojson_io.py
@@ -30,9 +30,7 @@ class TestOqtGeoJsonIO(unittest.TestCase):
             topic=self.topic_key,
             bpolys=self.feature,
         )
-        feature = asyncio.run(
-            oqt.create_indicator_as_geojson(patameters, key=self.name)
-        )
+        feature = asyncio.run(oqt.create_indicator(patameters, key=self.name))
         self.assertIsInstance(feature, FeatureCollection)
 
 

--- a/tests/integrationtests/test_raster.py
+++ b/tests/integrationtests/test_raster.py
@@ -1,5 +1,5 @@
 import ohsome_quality_analyst.raster.client as raster_client
-from ohsome_quality_analyst.definitions import get_raster_dataset
+from ohsome_quality_analyst.raster.definitions import get_raster_dataset
 
 from .utils import get_geojson_fixture
 

--- a/tests/integrationtests/utils.py
+++ b/tests/integrationtests/utils.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import geojson
 import vcr
 
-from ohsome_quality_analyst.topics.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_preset
 from ohsome_quality_analyst.topics.models import TopicDefinition
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -41,7 +41,7 @@ def get_geojson_fixture(name):
 
 
 def get_topic_fixture(name: str) -> TopicDefinition:
-    return get_topic_definition(name)
+    return get_topic_preset(name)
 
 
 # usage example:

--- a/tests/integrationtests/utils.py
+++ b/tests/integrationtests/utils.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import geojson
 import vcr
 
-from ohsome_quality_analyst.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_definition
 from ohsome_quality_analyst.topics.models import TopicDefinition
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/tests/unittests/test_definitions.py
+++ b/tests/unittests/test_definitions.py
@@ -2,31 +2,15 @@ import unittest
 
 import pytest
 
-import ohsome_quality_analyst.indicators.definitions
-import ohsome_quality_analyst.reports.definitions
-import ohsome_quality_analyst.topics.definitions
 from ohsome_quality_analyst import definitions
 from ohsome_quality_analyst.indicators.models import (
     IndicatorMetadata as IndicatorMetadata,
 )
 from ohsome_quality_analyst.reports.base import ReportMetadata as ReportMetadata
-from ohsome_quality_analyst.topics.models import TopicDefinition
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 
 class TestDefinitions(unittest.TestCase):
-    def test_get_indicator_names(self):
-        names = ohsome_quality_analyst.indicators.definitions.get_indicator_keys()
-        self.assertIsInstance(names, list)
-
-    def test_get_report_names(self):
-        names = ohsome_quality_analyst.reports.definitions.get_report_keys()
-        self.assertIsInstance(names, list)
-
-    def test_get_topic_keys(self):
-        names = ohsome_quality_analyst.topics.definitions.get_topic_keys()
-        self.assertIsInstance(names, list)
-
     def test_get_dataset_names(self):
         names = definitions.get_dataset_names()
         self.assertIsInstance(names, list)
@@ -63,88 +47,6 @@ class TestDefinitions(unittest.TestCase):
         )
 
         self.assertRaises(AssertionError, definitions.get_attribution, ["MSO"])
-
-    def test_get_valid_indicators(self):
-        indicators = ohsome_quality_analyst.indicators.definitions.get_valid_indicators(
-            "building-count"
-        )
-        self.assertEqual(
-            indicators,
-            (
-                "mapping-saturation",
-                "currentness",
-                "attribute-completeness",
-            ),
-        )
-
-    def test_get_valid_topics(self):
-        topics = ohsome_quality_analyst.topics.definitions.get_valid_topics("minimal")
-        self.assertEqual(topics, ("minimal",))
-
-
-def test_load_topic_definition():
-    topics = ohsome_quality_analyst.topics.definitions.load_topic_presets()
-    for topic in topics:
-        assert isinstance(topics[topic], TopicDefinition)
-
-
-def test_get_topic_definition():
-    topic = ohsome_quality_analyst.topics.definitions.get_topic_preset("minimal")
-    assert isinstance(topic, TopicDefinition)
-
-
-def test_get_topic_definition_not_found_error():
-    with pytest.raises(KeyError):
-        ohsome_quality_analyst.topics.definitions.get_topic_preset("foo")
-    with pytest.raises(KeyError):
-        ohsome_quality_analyst.topics.definitions.get_topic_preset(None)
-
-
-def test_get_topic_definitions():
-    topics = ohsome_quality_analyst.topics.definitions.get_topic_presets()
-    assert isinstance(topics, dict)
-    for topic in topics.values():
-        assert isinstance(topic, TopicDefinition)
-
-
-def test_get_indicator_definitions():
-    indicators = ohsome_quality_analyst.indicators.definitions.get_indicator_metadata()
-    assert isinstance(indicators, dict)
-    for indicator in indicators.values():
-        assert isinstance(indicator, IndicatorMetadata)
-
-
-def test_get_indicator_definitions_with_project():
-    indicators = ohsome_quality_analyst.indicators.definitions.get_indicator_metadata(
-        "core"
-    )
-    assert isinstance(indicators, dict)
-    for indicator in indicators.values():
-        assert isinstance(indicator, IndicatorMetadata)
-        assert indicator.projects == ["core"]
-
-
-def test_get_report_definitions():
-    reports = ohsome_quality_analyst.reports.definitions.get_report_metadata()
-    assert isinstance(reports, dict)
-    for report in reports.values():
-        assert isinstance(report, ReportMetadata)
-
-
-def test_get_report_definitions_with_project():
-    reports = ohsome_quality_analyst.reports.definitions.get_report_metadata("core")
-    assert isinstance(reports, dict)
-    for report in reports.values():
-        assert isinstance(report, ReportMetadata)
-        assert report.project == "core"
-
-
-def test_get_topic_definitions_with_project():
-    topics = ohsome_quality_analyst.topics.definitions.get_topic_presets("core")
-    assert isinstance(topics, dict)
-    for topic in topics.values():
-        assert isinstance(topic, TopicDefinition)
-        assert topic.project == "core"
 
 
 def test_load_metadata_indicator():

--- a/tests/unittests/test_definitions.py
+++ b/tests/unittests/test_definitions.py
@@ -7,23 +7,9 @@ from ohsome_quality_analyst.indicators.models import (
     IndicatorMetadata as IndicatorMetadata,
 )
 from ohsome_quality_analyst.reports.base import ReportMetadata as ReportMetadata
-from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 
 class TestDefinitions(unittest.TestCase):
-    def test_get_raster_dataset_names(self):
-        names = definitions.get_raster_dataset_names()
-        self.assertIsInstance(names, list)
-        self.assertTrue(names)
-
-    def test_get_raster_dataset(self):
-        raster = definitions.get_raster_dataset("GHS_BUILT_R2018A")
-        self.assertIsInstance(raster, definitions.RasterDataset)
-
-    def test_get_raster_dataset_undefined(self):
-        with self.assertRaises(RasterDatasetUndefinedError):
-            definitions.get_raster_dataset("foo")
-
     def test_get_attribution(self):
         attribution = definitions.get_attribution(["OSM"])
         self.assertEqual(attribution, "© OpenStreetMap contributors")

--- a/tests/unittests/test_definitions.py
+++ b/tests/unittests/test_definitions.py
@@ -11,18 +11,10 @@ from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 
 class TestDefinitions(unittest.TestCase):
-    def test_get_dataset_names(self):
-        names = definitions.get_dataset_names()
-        self.assertIsInstance(names, list)
-
     def test_get_raster_dataset_names(self):
         names = definitions.get_raster_dataset_names()
         self.assertIsInstance(names, list)
         self.assertTrue(names)
-
-    def test_get_fid_fields(self):
-        fields = definitions.get_fid_fields()
-        self.assertIsInstance(fields, list)
 
     def test_get_raster_dataset(self):
         raster = definitions.get_raster_dataset("GHS_BUILT_R2018A")

--- a/tests/unittests/test_definitions.py
+++ b/tests/unittests/test_definitions.py
@@ -16,11 +16,11 @@ from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 class TestDefinitions(unittest.TestCase):
     def test_get_indicator_names(self):
-        names = ohsome_quality_analyst.indicators.definitions.get_indicator_names()
+        names = ohsome_quality_analyst.indicators.definitions.get_indicator_keys()
         self.assertIsInstance(names, list)
 
     def test_get_report_names(self):
-        names = ohsome_quality_analyst.reports.definitions.get_report_names()
+        names = ohsome_quality_analyst.reports.definitions.get_report_keys()
         self.assertIsInstance(names, list)
 
     def test_get_topic_keys(self):
@@ -83,42 +83,40 @@ class TestDefinitions(unittest.TestCase):
 
 
 def test_load_topic_definition():
-    topics = ohsome_quality_analyst.topics.definitions.load_topic_definitions()
+    topics = ohsome_quality_analyst.topics.definitions.load_topic_presets()
     for topic in topics:
         assert isinstance(topics[topic], TopicDefinition)
 
 
 def test_get_topic_definition():
-    topic = ohsome_quality_analyst.topics.definitions.get_topic_definition("minimal")
+    topic = ohsome_quality_analyst.topics.definitions.get_topic_preset("minimal")
     assert isinstance(topic, TopicDefinition)
 
 
 def test_get_topic_definition_not_found_error():
     with pytest.raises(KeyError):
-        ohsome_quality_analyst.topics.definitions.get_topic_definition("foo")
+        ohsome_quality_analyst.topics.definitions.get_topic_preset("foo")
     with pytest.raises(KeyError):
-        ohsome_quality_analyst.topics.definitions.get_topic_definition(None)
+        ohsome_quality_analyst.topics.definitions.get_topic_preset(None)
 
 
 def test_get_topic_definitions():
-    topics = ohsome_quality_analyst.topics.definitions.get_topic_definitions()
+    topics = ohsome_quality_analyst.topics.definitions.get_topic_presets()
     assert isinstance(topics, dict)
     for topic in topics.values():
         assert isinstance(topic, TopicDefinition)
 
 
 def test_get_indicator_definitions():
-    indicators = (
-        ohsome_quality_analyst.indicators.definitions.get_indicator_definitions()
-    )
+    indicators = ohsome_quality_analyst.indicators.definitions.get_indicator_metadata()
     assert isinstance(indicators, dict)
     for indicator in indicators.values():
         assert isinstance(indicator, IndicatorMetadata)
 
 
 def test_get_indicator_definitions_with_project():
-    indicators = (
-        ohsome_quality_analyst.indicators.definitions.get_indicator_definitions("core")
+    indicators = ohsome_quality_analyst.indicators.definitions.get_indicator_metadata(
+        "core"
     )
     assert isinstance(indicators, dict)
     for indicator in indicators.values():
@@ -127,14 +125,14 @@ def test_get_indicator_definitions_with_project():
 
 
 def test_get_report_definitions():
-    reports = ohsome_quality_analyst.reports.definitions.get_report_definitions()
+    reports = ohsome_quality_analyst.reports.definitions.get_report_metadata()
     assert isinstance(reports, dict)
     for report in reports.values():
         assert isinstance(report, ReportMetadata)
 
 
 def test_get_report_definitions_with_project():
-    reports = ohsome_quality_analyst.reports.definitions.get_report_definitions("core")
+    reports = ohsome_quality_analyst.reports.definitions.get_report_metadata("core")
     assert isinstance(reports, dict)
     for report in reports.values():
         assert isinstance(report, ReportMetadata)
@@ -142,7 +140,7 @@ def test_get_report_definitions_with_project():
 
 
 def test_get_topic_definitions_with_project():
-    topics = ohsome_quality_analyst.topics.definitions.get_topic_definitions("core")
+    topics = ohsome_quality_analyst.topics.definitions.get_topic_presets("core")
     assert isinstance(topics, dict)
     for topic in topics.values():
         assert isinstance(topic, TopicDefinition)

--- a/tests/unittests/test_definitions.py
+++ b/tests/unittests/test_definitions.py
@@ -2,6 +2,9 @@ import unittest
 
 import pytest
 
+import ohsome_quality_analyst.indicators.definitions
+import ohsome_quality_analyst.reports.definitions
+import ohsome_quality_analyst.topics.definitions
 from ohsome_quality_analyst import definitions
 from ohsome_quality_analyst.indicators.models import (
     IndicatorMetadata as IndicatorMetadata,
@@ -13,15 +16,15 @@ from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
 
 class TestDefinitions(unittest.TestCase):
     def test_get_indicator_names(self):
-        names = definitions.get_indicator_names()
+        names = ohsome_quality_analyst.indicators.definitions.get_indicator_names()
         self.assertIsInstance(names, list)
 
     def test_get_report_names(self):
-        names = definitions.get_report_names()
+        names = ohsome_quality_analyst.reports.definitions.get_report_names()
         self.assertIsInstance(names, list)
 
     def test_get_topic_keys(self):
-        names = definitions.get_topic_keys()
+        names = ohsome_quality_analyst.topics.definitions.get_topic_keys()
         self.assertIsInstance(names, list)
 
     def test_get_dataset_names(self):
@@ -62,7 +65,9 @@ class TestDefinitions(unittest.TestCase):
         self.assertRaises(AssertionError, definitions.get_attribution, ["MSO"])
 
     def test_get_valid_indicators(self):
-        indicators = definitions.get_valid_indicators("building-count")
+        indicators = ohsome_quality_analyst.indicators.definitions.get_valid_indicators(
+            "building-count"
+        )
         self.assertEqual(
             indicators,
             (
@@ -73,44 +78,48 @@ class TestDefinitions(unittest.TestCase):
         )
 
     def test_get_valid_topics(self):
-        topics = definitions.get_valid_topics("minimal")
+        topics = ohsome_quality_analyst.topics.definitions.get_valid_topics("minimal")
         self.assertEqual(topics, ("minimal",))
 
 
 def test_load_topic_definition():
-    topics = definitions.load_topic_definitions()
+    topics = ohsome_quality_analyst.topics.definitions.load_topic_definitions()
     for topic in topics:
         assert isinstance(topics[topic], TopicDefinition)
 
 
 def test_get_topic_definition():
-    topic = definitions.get_topic_definition("minimal")
+    topic = ohsome_quality_analyst.topics.definitions.get_topic_definition("minimal")
     assert isinstance(topic, TopicDefinition)
 
 
 def test_get_topic_definition_not_found_error():
     with pytest.raises(KeyError):
-        definitions.get_topic_definition("foo")
+        ohsome_quality_analyst.topics.definitions.get_topic_definition("foo")
     with pytest.raises(KeyError):
-        definitions.get_topic_definition(None)
+        ohsome_quality_analyst.topics.definitions.get_topic_definition(None)
 
 
 def test_get_topic_definitions():
-    topics = definitions.get_topic_definitions()
+    topics = ohsome_quality_analyst.topics.definitions.get_topic_definitions()
     assert isinstance(topics, dict)
     for topic in topics.values():
         assert isinstance(topic, TopicDefinition)
 
 
 def test_get_indicator_definitions():
-    indicators = definitions.get_indicator_definitions()
+    indicators = (
+        ohsome_quality_analyst.indicators.definitions.get_indicator_definitions()
+    )
     assert isinstance(indicators, dict)
     for indicator in indicators.values():
         assert isinstance(indicator, IndicatorMetadata)
 
 
 def test_get_indicator_definitions_with_project():
-    indicators = definitions.get_indicator_definitions("core")
+    indicators = (
+        ohsome_quality_analyst.indicators.definitions.get_indicator_definitions("core")
+    )
     assert isinstance(indicators, dict)
     for indicator in indicators.values():
         assert isinstance(indicator, IndicatorMetadata)
@@ -118,14 +127,14 @@ def test_get_indicator_definitions_with_project():
 
 
 def test_get_report_definitions():
-    reports = definitions.get_report_definitions()
+    reports = ohsome_quality_analyst.reports.definitions.get_report_definitions()
     assert isinstance(reports, dict)
     for report in reports.values():
         assert isinstance(report, ReportMetadata)
 
 
 def test_get_report_definitions_with_project():
-    reports = definitions.get_report_definitions("core")
+    reports = ohsome_quality_analyst.reports.definitions.get_report_definitions("core")
     assert isinstance(reports, dict)
     for report in reports.values():
         assert isinstance(report, ReportMetadata)
@@ -133,7 +142,7 @@ def test_get_report_definitions_with_project():
 
 
 def test_get_topic_definitions_with_project():
-    topics = definitions.get_topic_definitions("core")
+    topics = ohsome_quality_analyst.topics.definitions.get_topic_definitions("core")
     assert isinstance(topics, dict)
     for topic in topics.values():
         assert isinstance(topic, TopicDefinition)

--- a/tests/unittests/test_indicators_definitions.py
+++ b/tests/unittests/test_indicators_definitions.py
@@ -1,0 +1,26 @@
+from ohsome_quality_analyst.indicators import definitions, models
+
+
+def test_get_indicator_names():
+    names = definitions.get_indicator_keys()
+    assert isinstance(names, list)
+
+
+def test_get_valid_indicators():
+    indicators = definitions.get_valid_indicators("building-count")
+    assert indicators == ("mapping-saturation", "currentness", "attribute-completeness")
+
+
+def test_get_indicator_definitions():
+    indicators = definitions.get_indicator_metadata()
+    assert isinstance(indicators, dict)
+    for indicator in indicators.values():
+        assert isinstance(indicator, models.IndicatorMetadata)
+
+
+def test_get_indicator_definitions_with_project():
+    indicators = definitions.get_indicator_metadata("core")
+    assert isinstance(indicators, dict)
+    for indicator in indicators.values():
+        assert isinstance(indicator, models.IndicatorMetadata)
+        assert indicator.projects == ["core"]

--- a/tests/unittests/test_project_definitions.py
+++ b/tests/unittests/test_project_definitions.py
@@ -10,7 +10,7 @@ def valid_project_keys(request):
 
 
 def test_get_projects():
-    qds = definitions.get_projects()
+    qds = definitions.get_project_metadata()
     assert isinstance(qds, dict)
     for key, qd in qds.items():
         assert isinstance(key, str)

--- a/tests/unittests/test_raster.py
+++ b/tests/unittests/test_raster.py
@@ -6,7 +6,7 @@ from unittest import mock
 import geojson
 
 import ohsome_quality_analyst.raster.client as raster_client
-from ohsome_quality_analyst.definitions import get_raster_dataset
+from ohsome_quality_analyst.raster.definitions import get_raster_dataset
 from ohsome_quality_analyst.utils.exceptions import RasterDatasetNotFoundError
 
 

--- a/tests/unittests/test_raster_definitions.py
+++ b/tests/unittests/test_raster_definitions.py
@@ -1,0 +1,19 @@
+import unittest
+
+from ohsome_quality_analyst.raster import definitions
+from ohsome_quality_analyst.utils.exceptions import RasterDatasetUndefinedError
+
+
+class TestDefinitions(unittest.TestCase):
+    def test_get_raster_dataset_names(self):
+        names = definitions.get_raster_dataset_names()
+        self.assertIsInstance(names, list)
+        self.assertTrue(names)
+
+    def test_get_raster_dataset(self):
+        raster = definitions.get_raster_dataset("GHS_BUILT_R2018A")
+        self.assertIsInstance(raster, definitions.RasterDataset)
+
+    def test_get_raster_dataset_undefined(self):
+        with self.assertRaises(RasterDatasetUndefinedError):
+            definitions.get_raster_dataset("foo")

--- a/tests/unittests/test_reports_definitions.py
+++ b/tests/unittests/test_reports_definitions.py
@@ -1,0 +1,21 @@
+from ohsome_quality_analyst.reports import definitions, models
+
+
+def test_get_report_names():
+    names = definitions.get_report_keys()
+    assert isinstance(names, list)
+
+
+def test_get_report_definitions_with_project():
+    reports = definitions.get_report_metadata("core")
+    assert isinstance(reports, dict)
+    for report in reports.values():
+        assert isinstance(report, models.ReportMetadata)
+        assert report.project == "core"
+
+
+def test_get_report_definitions():
+    reports = definitions.get_report_metadata()
+    assert isinstance(reports, dict)
+    for report in reports.values():
+        assert isinstance(report, models.ReportMetadata)

--- a/tests/unittests/test_topics_definitions.py
+++ b/tests/unittests/test_topics_definitions.py
@@ -1,0 +1,46 @@
+import pytest
+
+from ohsome_quality_analyst.topics import definitions, models
+
+
+def test_get_topic_keys():
+    names = definitions.get_topic_keys()
+    assert isinstance(names, list)
+
+
+def test_get_valid_topics():
+    topics = definitions.get_valid_topics("minimal")
+    assert topics == ("minimal",)
+
+
+def test_load_topic_definition():
+    topics = definitions.load_topic_presets()
+    for topic in topics:
+        assert isinstance(topics[topic], models.TopicDefinition)
+
+
+def test_get_topic_definition():
+    topic = definitions.get_topic_preset("minimal")
+    assert isinstance(topic, models.TopicDefinition)
+
+
+def test_get_topic_definition_not_found_error():
+    with pytest.raises(KeyError):
+        definitions.get_topic_preset("foo")
+    with pytest.raises(KeyError):
+        definitions.get_topic_preset(None)
+
+
+def test_get_topic_definitions():
+    topics = definitions.get_topic_presets()
+    assert isinstance(topics, dict)
+    for topic in topics.values():
+        assert isinstance(topic, models.TopicDefinition)
+
+
+def test_get_topic_definitions_with_project():
+    topics = definitions.get_topic_presets("core")
+    assert isinstance(topics, dict)
+    for topic in topics.values():
+        assert isinstance(topic, models.TopicDefinition)
+        assert topic.project == "core"

--- a/tests/unittests/utils.py
+++ b/tests/unittests/utils.py
@@ -2,7 +2,7 @@ import os
 
 import geojson
 
-from ohsome_quality_analyst.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_definition
 from ohsome_quality_analyst.topics.models import TopicDefinition
 
 

--- a/tests/unittests/utils.py
+++ b/tests/unittests/utils.py
@@ -2,7 +2,7 @@ import os
 
 import geojson
 
-from ohsome_quality_analyst.topics.definitions import get_topic_definition
+from ohsome_quality_analyst.topics.definitions import get_topic_preset
 from ohsome_quality_analyst.topics.models import TopicDefinition
 
 
@@ -13,4 +13,4 @@ def get_geojson_fixture(name):
 
 
 def get_topic_fixture(name: str) -> TopicDefinition:
-    return get_topic_definition(name)
+    return get_topic_preset(name)


### PR DESCRIPTION
### Description
- refactor: move raster definitions to own module
- refactor: remove get dataset and fid_field funcs
- test: refactor test case for definitions modules
- refactor: align func names of definition modules
- refactor(definitions): move funcs from root definitions
- refactor: move enums to defintions modules
- refactor(oqt): rename functions

### Corresponding issue
Closes None

### New or changed dependencies
- None

### Checklist
- [x] I have updated my branch to `main` (e.g. through `git rebase main`)
- [x] My code follows the [style guide](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#style-guide) and was checked with [pre-commit](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CONTRIBUTING.md#pre-commit) before committing
- [x] I have commented my code
- [x] I have added sufficient unit and integration [tests](https://github.com/GIScience/ohsome-quality-analyst/blob/main/docs/development_setup.md#tests)
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/ohsome-quality-analyst/blob/main/CHANGELOG.md)~